### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/168/781/421168781.geojson
+++ b/data/421/168/781/421168781.geojson
@@ -543,6 +543,9 @@
     },
     "wof:country":"MW",
     "wof:created":1459008780,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aa87de802bd4969eacf12a5f73c97ef0",
     "wof:hierarchy":[
         {
@@ -552,7 +555,7 @@
         }
     ],
     "wof:id":421168781,
-    "wof:lastmodified":1566612562,
+    "wof:lastmodified":1582331736,
     "wof:name":"Lilongwe",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/323/83/85632383.geojson
+++ b/data/856/323/83/85632383.geojson
@@ -901,6 +901,10 @@
     },
     "wof:country":"MW",
     "wof:country_alpha3":"MWI",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"8e34ffe4400307584143030831fb7862",
     "wof:hierarchy":[
         {
@@ -917,7 +921,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1566612266,
+    "wof:lastmodified":1582331729,
     "wof:name":"Malawi",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/750/01/85675001.geojson
+++ b/data/856/750/01/85675001.geojson
@@ -54,6 +54,9 @@
         "gp:id":20070125
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"70eaad21ce3078112c6278c4c9de474b",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1529540333,
+    "wof:lastmodified":1582331731,
     "wof:name":"Chitipa",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/11/85675011.geojson
+++ b/data/856/750/11/85675011.geojson
@@ -65,6 +65,9 @@
         "wd:id":"Q195309"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"22a4f22e15223d85535fbd8e55dc3aed",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1529540335,
+    "wof:lastmodified":1582331730,
     "wof:name":"Kasungu",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/15/85675015.geojson
+++ b/data/856/750/15/85675015.geojson
@@ -65,6 +65,9 @@
         "wd:id":"Q1666876"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d70f6efe50fb44ee35dee56804cab5ed",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1529540366,
+    "wof:lastmodified":1582331731,
     "wof:name":"Mzimba",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/19/85675019.geojson
+++ b/data/856/750/19/85675019.geojson
@@ -61,6 +61,9 @@
         "qs:id":236296
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a9b826adef95b91c7bbaa48ad490a47",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1529540370,
+    "wof:lastmodified":1582331730,
     "wof:name":"Nkhata Bay",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/25/85675025.geojson
+++ b/data/856/750/25/85675025.geojson
@@ -65,6 +65,9 @@
         "wd:id":"Q1022510"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eda1d8b9ebcb628ca559943b8a46dbd9",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1529540337,
+    "wof:lastmodified":1582331732,
     "wof:name":"Nkhotakota",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/29/85675029.geojson
+++ b/data/856/750/29/85675029.geojson
@@ -63,6 +63,9 @@
         "unlc:id":"MW-RU"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f8660241eba41dd5891040a4edf29ec",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1529540337,
+    "wof:lastmodified":1582331730,
     "wof:name":"Rumphi",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/33/85675033.geojson
+++ b/data/856/750/33/85675033.geojson
@@ -61,6 +61,9 @@
         "unlc:id":"MW-MH"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2093b6d59964d081aa8040cf994b2643",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1529540337,
+    "wof:lastmodified":1582331730,
     "wof:name":"Machinga",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/37/85675037.geojson
+++ b/data/856/750/37/85675037.geojson
@@ -65,6 +65,9 @@
         "wd:id":"Q1182266"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8d819ebd38cc9fe7469c4672182d27c7",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1529540337,
+    "wof:lastmodified":1582331731,
     "wof:name":"Dedza",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/45/85675045.geojson
+++ b/data/856/750/45/85675045.geojson
@@ -68,6 +68,9 @@
         "wd:id":"Q3038288"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3026253d29548d3eaf5f7e2fffb9357f",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1529540337,
+    "wof:lastmodified":1582331730,
     "wof:name":"Dowa",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/47/85675047.geojson
+++ b/data/856/750/47/85675047.geojson
@@ -72,6 +72,9 @@
         "unlc:id":"MW-LI"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3745b40c42b1b596a753da7df8aad619",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1561749656,
+    "wof:lastmodified":1582331731,
     "wof:name":"Lilongwe",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/51/85675051.geojson
+++ b/data/856/750/51/85675051.geojson
@@ -63,6 +63,9 @@
         "unlc:id":"MW-MG"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f2df694ea9dbf3a09d2ea42e19d5d86",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1529540338,
+    "wof:lastmodified":1582331730,
     "wof:name":"Mangochi",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/55/85675055.geojson
+++ b/data/856/750/55/85675055.geojson
@@ -65,6 +65,9 @@
         "wd:id":"Q1188150"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a0b8190e903f7b8e3625535d045df6d",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1529540338,
+    "wof:lastmodified":1582331731,
     "wof:name":"Mchinji",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/61/85675061.geojson
+++ b/data/856/750/61/85675061.geojson
@@ -65,6 +65,9 @@
         "wd:id":"Q1022517"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0708c0bf51f08c05e02433b37e431d18",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1529540359,
+    "wof:lastmodified":1582331730,
     "wof:name":"Ntcheu",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/63/85675063.geojson
+++ b/data/856/750/63/85675063.geojson
@@ -65,6 +65,9 @@
         "wd:id":"Q912391"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7382547b16b7b33ad18d6c25837e6b0e",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1529540362,
+    "wof:lastmodified":1582331731,
     "wof:name":"Ntchisi",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/69/85675069.geojson
+++ b/data/856/750/69/85675069.geojson
@@ -71,6 +71,9 @@
         "wd:id":"Q526053"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9bdc26487aa23b85978bcca25476dd19",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1529540362,
+    "wof:lastmodified":1582331730,
     "wof:name":"Salima",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/71/85675071.geojson
+++ b/data/856/750/71/85675071.geojson
@@ -83,6 +83,9 @@
         "wd:id":"Q3208475"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7cbbe3901e9a324bd0ed1d2e131dfa64",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1529540362,
+    "wof:lastmodified":1582331731,
     "wof:name":"Balaka",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/75/85675075.geojson
+++ b/data/856/750/75/85675075.geojson
@@ -63,6 +63,9 @@
         "unlc:id":"MW-CK"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"12849b6c8a70973f096c13982bbd5c3b",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1529540364,
+    "wof:lastmodified":1582331731,
     "wof:name":"Chikwawa",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/81/85675081.geojson
+++ b/data/856/750/81/85675081.geojson
@@ -63,6 +63,9 @@
         "unlc:id":"MW-CR"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ceb806e77719ca7da3ce02158806e269",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1529540332,
+    "wof:lastmodified":1582331731,
     "wof:name":"Chiradzulu",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/85/85675085.geojson
+++ b/data/856/750/85/85675085.geojson
@@ -97,6 +97,9 @@
         "wd:id":"Q2144010"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a687a5d72a99c67b9ae556d13e967ad",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1529540332,
+    "wof:lastmodified":1582331731,
     "wof:name":"Thyolo",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/89/85675089.geojson
+++ b/data/856/750/89/85675089.geojson
@@ -63,6 +63,9 @@
         "unlc:id":"MW-NS"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4dc1658ea762ae7c501c99b3e1866c94",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1529540333,
+    "wof:lastmodified":1582331730,
     "wof:name":"Nsanje",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/93/85675093.geojson
+++ b/data/856/750/93/85675093.geojson
@@ -92,6 +92,9 @@
         "wd:id":"Q219100"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"641c84f33c4ff4e54e6e532af2d3bb21",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1529540333,
+    "wof:lastmodified":1582331730,
     "wof:name":"Zomba",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/750/99/85675099.geojson
+++ b/data/856/750/99/85675099.geojson
@@ -63,6 +63,9 @@
         "unlc:id":"MW-BL"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ff37500d30ded802e052f6a1476dd951",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1529540333,
+    "wof:lastmodified":1582331731,
     "wof:name":"Blantyre",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/751/03/85675103.geojson
+++ b/data/856/751/03/85675103.geojson
@@ -61,6 +61,9 @@
         "qs:id":128263
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"99c96ef6f8825be83a22942d87bc72c8",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1529540334,
+    "wof:lastmodified":1582331729,
     "wof:name":"Mwanza",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/751/07/85675107.geojson
+++ b/data/856/751/07/85675107.geojson
@@ -63,6 +63,9 @@
         "unlc:id":"MW-MU"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"65129c7ec769eb53f00f309da1706ad7",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1529540334,
+    "wof:lastmodified":1582331730,
     "wof:name":"Mulanje",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/751/09/85675109.geojson
+++ b/data/856/751/09/85675109.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Phalombe"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4160a0949e7621738bb81f22492ca259",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1529540335,
+    "wof:lastmodified":1582331730,
     "wof:name":"Phalombe",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/751/19/85675119.geojson
+++ b/data/856/751/19/85675119.geojson
@@ -65,6 +65,9 @@
         "wd:id":"Q15947648"
     },
     "wof:country":"MW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3918409d74b9b86d676b76e04cf0b819",
     "wof:hierarchy":[
         {
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":85675119,
-    "wof:lastmodified":1529540335,
+    "wof:lastmodified":1582331729,
     "wof:name":"Nemo",
     "wof:parent_id":85632383,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.