### PR TITLE
Name updates

### DIFF
--- a/data/421/168/777/421168777.geojson
+++ b/data/421/168/777/421168777.geojson
@@ -165,7 +165,7 @@
         "\u0b9a\u0bcb\u0bae\u0bcd\u0baa\u0bbe"
     ],
     "name:tam_x_variant":[
-        "\u0b9a\u0bcb\u0bae\u0bcd\u0baa\u0bbe "
+        "\u0b9a\u0bcb\u0bae\u0bcd\u0baa\u0bbe"
     ],
     "name:tel_x_preferred":[
         "\u0c1c\u0c4b\u0c02\u0c2c\u0c3e"
@@ -189,7 +189,7 @@
         "\u0632\u0648\u0645\u0628\u0627 \u060c \u0645\u0627\u0644\u0627\u0648\u06cc"
     ],
     "name:urd_x_variant":[
-        "\u0632\u0648\u0645\u0628\u0627 "
+        "\u0632\u0648\u0645\u0628\u0627"
     ],
     "name:uzb_x_preferred":[
         "Zomba"
@@ -340,7 +340,7 @@
         }
     ],
     "wof:id":421168777,
-    "wof:lastmodified":1566612562,
+    "wof:lastmodified":1587163137,
     "wof:name":"Zomba",
     "wof:parent_id":1108784765,
     "wof:placetype":"locality",

--- a/data/856/323/83/85632383.geojson
+++ b/data/856/323/83/85632383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.915836,
-    "geom:area_square_m":119295851164.192184,
+    "geom:area_square_m":119295851832.450195,
     "geom:bbox":"32.678889,-17.135278,35.924166,-9.367181",
     "geom:latitude":-13.221586,
     "geom:longitude":34.30758,
@@ -52,6 +52,9 @@
     "name:arg_x_variant":[
         "Malaui"
     ],
+    "name:ary_x_preferred":[
+        "\u0645\u0627\u0644\u0627\u0648\u064a"
+    ],
     "name:arz_x_preferred":[
         "\u0645\u0627\u0644\u0627\u0648\u0649"
     ],
@@ -71,6 +74,9 @@
         "\u041c\u0430\u043b\u0430\u0432\u0438"
     ],
     "name:bam_x_preferred":[
+        "Malawi"
+    ],
+    "name:ban_x_preferred":[
         "Malawi"
     ],
     "name:bcl_x_preferred":[
@@ -145,6 +151,12 @@
     "name:dan_x_preferred":[
         "Malawi"
     ],
+    "name:deu_at_x_preferred":[
+        "Malawi"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Malawi"
+    ],
     "name:deu_x_preferred":[
         "Malawi"
     ],
@@ -165,6 +177,12 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03b1\u03bb\u03ac\u03bf\u03c5\u03b9"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Malawi"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Malawi"
     ],
     "name:eng_x_preferred":[
         "Malawi"
@@ -222,6 +240,9 @@
     ],
     "name:gag_x_preferred":[
         "Malavi"
+    ],
+    "name:gcr_x_preferred":[
+        "Malawi"
     ],
     "name:gla_x_preferred":[
         "Malabhaidh"
@@ -441,6 +462,9 @@
     "name:mon_x_preferred":[
         "\u041c\u0430\u043b\u0430\u0432\u0438"
     ],
+    "name:mri_x_preferred":[
+        "Mar\u0101wi"
+    ],
     "name:msa_x_preferred":[
         "Malawi"
     ],
@@ -540,6 +564,9 @@
     "name:pol_x_preferred":[
         "Malawi"
     ],
+    "name:por_br_x_preferred":[
+        "Malawi"
+    ],
     "name:por_x_preferred":[
         "Malau\u00ed",
         "Malawi"
@@ -596,8 +623,14 @@
     "name:sme_x_preferred":[
         "Malawi"
     ],
+    "name:smo_x_preferred":[
+        "Malawi"
+    ],
     "name:sna_x_preferred":[
         "Malawi"
+    ],
+    "name:snd_x_preferred":[
+        "\u0645\u0644\u0627\u0648\u064a"
     ],
     "name:som_x_preferred":[
         "Malaawi"
@@ -616,6 +649,12 @@
     ],
     "name:srd_x_preferred":[
         "Malawi"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u041c\u0430\u043b\u0430\u0432\u0438"
+    ],
+    "name:srp_el_x_preferred":[
+        "Malavi"
     ],
     "name:srp_x_preferred":[
         "\u041c\u0430\u043b\u0430\u0432\u0438"
@@ -636,6 +675,9 @@
         "Malawi"
     ],
     "name:szl_x_preferred":[
+        "Malawi"
+    ],
+    "name:szy_x_preferred":[
         "Malawi"
     ],
     "name:tam_x_preferred":[
@@ -682,6 +724,9 @@
     ],
     "name:tur_x_preferred":[
         "Malavi"
+    ],
+    "name:twi_x_preferred":[
+        "Malawi"
     ],
     "name:udm_x_preferred":[
         "\u041c\u0430\u043b\u0430\u0432\u0438"
@@ -756,6 +801,9 @@
     ],
     "name:zho_min_nan_x_preferred":[
         "Mala\u0175i"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u99ac\u62c9\u5a01"
     ],
     "name:zho_x_preferred":[
         "\u9a6c\u62c9\u7ef4"
@@ -922,7 +970,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1583797397,
+    "wof:lastmodified":1587428914,
     "wof:name":"Malawi",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.