### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/586/523/5/1125865235.geojson
+++ b/data/112/586/523/5/1125865235.geojson
@@ -100,6 +100,9 @@
     "name:kor_x_preferred":[
         "\ud314\ub86c\ubca0 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ud314\ub86c\ubca0\ud604"
+    ],
     "name:lav_x_preferred":[
         "Falombes distrikts"
     ],
@@ -111,6 +114,9 @@
     ],
     "name:msa_x_preferred":[
         "Phalombe District"
+    ],
+    "name:nan_x_preferred":[
+        "Phalombe Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Phalombe"
@@ -169,6 +175,9 @@
     "name:zho_x_preferred":[
         "\u6cd5\u9686\u8c9d\u7e23"
     ],
+    "name:zul_x_preferred":[
+        "Phalombe District"
+    ],
     "qs_pg:aaroncc":"MW",
     "qs_pg:gn_country":"MW",
     "qs_pg:gn_fcode":"PPLA2",
@@ -217,7 +226,7 @@
         }
     ],
     "wof:id":1125865235,
-    "wof:lastmodified":1636497497,
+    "wof:lastmodified":1690846548,
     "wof:name":"Phalombe",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/894/1/1141908941.geojson
+++ b/data/114/190/894/1/1141908941.geojson
@@ -36,6 +36,9 @@
     "name:fas_x_preferred":[
         "\u0686\u06cc\u0631\u0648\u0645\u0648"
     ],
+    "name:fra_x_preferred":[
+        "Chiromo"
+    ],
     "name:heb_x_preferred":[
         "\u05e6'\u05d9\u05e8\u05d5\u05de\u05d5"
     ],
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":1141908941,
-    "wof:lastmodified":1636497500,
+    "wof:lastmodified":1690846549,
     "wof:name":"Chiromo",
     "wof:parent_id":85675089,
     "wof:placetype":"locality",

--- a/data/114/190/926/1/1141909261.geojson
+++ b/data/114/190/926/1/1141909261.geojson
@@ -21,6 +21,12 @@
     "name:ara_x_preferred":[
         "\u0645\u0632\u0648\u0632\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0632\u0648\u0632\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Mzuzu"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0632\u0648\u0632\u0648"
     ],
@@ -28,6 +34,12 @@
         "\u09ae\u09c1\u099c\u09c1"
     ],
     "name:bre_x_preferred":[
+        "Mzuzu"
+    ],
+    "name:cat_x_preferred":[
+        "Mzuzu"
+    ],
+    "name:ces_x_preferred":[
         "Mzuzu"
     ],
     "name:dan_x_preferred":[
@@ -52,6 +64,9 @@
         "Mzuzu"
     ],
     "name:fra_x_preferred":[
+        "Mzuzu"
+    ],
+    "name:gle_x_preferred":[
         "Mzuzu"
     ],
     "name:glg_x_preferred":[
@@ -132,6 +147,9 @@
     "name:srp_x_preferred":[
         "\u041c\u0437\u0443\u0437\u0443"
     ],
+    "name:swa_x_preferred":[
+        "Mzuzu"
+    ],
     "name:swe_x_preferred":[
         "Mzuzu"
     ],
@@ -159,11 +177,17 @@
     "name:urd_x_preferred":[
         "\u0645\u0632\u0648\u0632\u0648"
     ],
+    "name:vec_x_preferred":[
+        "Mzuzu"
+    ],
     "name:vie_x_preferred":[
         "Mzuzu"
     ],
     "name:zho_x_preferred":[
         "\u59c6\u7956\u7956"
+    ],
+    "name:zul_x_preferred":[
+        "Mzuzu"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -286,7 +310,7 @@
         }
     ],
     "wof:id":1141909261,
-    "wof:lastmodified":1636497500,
+    "wof:lastmodified":1690846549,
     "wof:name":"Mzuzu",
     "wof:parent_id":85675015,
     "wof:placetype":"locality",

--- a/data/421/166/453/421166453.geojson
+++ b/data/421/166/453/421166453.geojson
@@ -38,6 +38,9 @@
     "name:und_x_variant":[
         "Chinteche"
     ],
+    "name:zul_x_preferred":[
+        "Chintheche"
+    ],
     "qs:gn_country":"MW",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":930727,
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":421166453,
-    "wof:lastmodified":1566612562,
+    "wof:lastmodified":1690846536,
     "wof:name":"Chintheche",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/166/455/421166455.geojson
+++ b/data/421/166/455/421166455.geojson
@@ -20,6 +20,15 @@
     "name:ara_x_preferred":[
         "\u062d\u064a \u0646\u0633\u0627\u0646\u062c\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u062d\u0649 \u0646\u0633\u0627\u0646\u062c\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Nsanje"
+    ],
+    "name:azb_x_preferred":[
+        "\u0646\u0633\u0627\u0646\u062c\u0647"
+    ],
     "name:ben_x_preferred":[
         "\u098f\u09a8\u09cd\u09b8\u09cd\u09af\u09be\u099e\u09cd\u099c\u09c7"
     ],
@@ -86,6 +95,9 @@
     "name:spa_x_preferred":[
         "Nsanje"
     ],
+    "name:swa_x_preferred":[
+        "Nsanje"
+    ],
     "name:swe_x_preferred":[
         "Nsanje"
     ],
@@ -106,6 +118,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6069\u6851\u5091"
+    ],
+    "name:zul_x_preferred":[
+        "Nsanje"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -245,7 +260,7 @@
         }
     ],
     "wof:id":421166455,
-    "wof:lastmodified":1636497490,
+    "wof:lastmodified":1690846536,
     "wof:name":"Nsanje",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/166/459/421166459.geojson
+++ b/data/421/166/459/421166459.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062d\u064a \u062f\u064a\u062f\u0632\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062d\u0649 \u062f\u064a\u062f\u0632\u0627"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u062f\u0632\u0627"
     ],
@@ -83,7 +86,13 @@
     "name:ron_x_preferred":[
         "Dedza"
     ],
+    "name:rus_x_preferred":[
+        "\u0414\u0435\u0434\u0437\u0430"
+    ],
     "name:spa_x_preferred":[
+        "Dedza"
+    ],
+    "name:swa_x_preferred":[
         "Dedza"
     ],
     "name:swe_x_preferred":[
@@ -106,6 +115,9 @@
     ],
     "name:zho_x_preferred":[
         "\u4ee3\u624e"
+    ],
+    "name:zul_x_preferred":[
+        "Dedza"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -242,7 +254,7 @@
         }
     ],
     "wof:id":421166459,
-    "wof:lastmodified":1636497490,
+    "wof:lastmodified":1690846537,
     "wof:name":"Dedza",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/167/167/421167167.geojson
+++ b/data/421/167/167/421167167.geojson
@@ -83,6 +83,9 @@
     "name:spa_x_preferred":[
         "Kasungu"
     ],
+    "name:swa_x_preferred":[
+        "Kasungu"
+    ],
     "name:swe_x_preferred":[
         "Kasungu"
     ],
@@ -91,6 +94,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u677e\u53e4"
+    ],
+    "name:zul_x_preferred":[
+        "Kasungu"
     ],
     "qs:gn_country":"MW",
     "qs:gn_fcode":"PPLA2",
@@ -135,7 +141,7 @@
         }
     ],
     "wof:id":421167167,
-    "wof:lastmodified":1636497490,
+    "wof:lastmodified":1690846537,
     "wof:name":"Kasungu",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/168/777/421168777.geojson
+++ b/data/421/168/777/421168777.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0632\u0648\u0645\u0628\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0632\u0648\u0645\u0628\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Zomba"
+    ],
     "name:azb_x_preferred":[
         "\u0632\u0648\u0645\u0628\u0627"
     ],
@@ -34,6 +40,9 @@
     ],
     "name:bre_x_preferred":[
         "Zomba"
+    ],
+    "name:bul_x_preferred":[
+        "\u0417\u043e\u043c\u0431\u0430"
     ],
     "name:cat_x_preferred":[
         "Zomba"
@@ -85,6 +94,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0a9d\u0acb\u0aae\u0acd\u0aac\u0abe"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d6\u05d5\u05de\u05d1\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u091c\u093c\u094b\u092e\u094d\u092c\u093e"
@@ -158,6 +170,9 @@
     "name:srp_x_preferred":[
         "\u0417\u043e\u043c\u0431\u0430"
     ],
+    "name:swa_x_preferred":[
+        "Zomba"
+    ],
     "name:swe_x_preferred":[
         "Zomba"
     ],
@@ -165,7 +180,7 @@
         "\u0b9a\u0bcb\u0bae\u0bcd\u0baa\u0bbe"
     ],
     "name:tam_x_variant":[
-        "\u0b9a\u0bcb\u0bae\u0bcd\u0baa\u0bbe"
+        "\u0b9a\u0bcb\u0bae\u0bcd\u0baa\u0bbe "
     ],
     "name:tel_x_preferred":[
         "\u0c1c\u0c4b\u0c02\u0c2c\u0c3e"
@@ -174,7 +189,8 @@
         "\u0e0b\u0e2d\u0e21\u0e1a\u0e49\u0e32"
     ],
     "name:tha_x_variant":[
-        "\u0e0b\u0e2d\u0e21\u0e1a\u0e49\u0e32 ,\u0e21\u0e32\u0e25\u0e32\u0e27\u0e35"
+        "\u0e0b\u0e2d\u0e21\u0e1a\u0e49\u0e32 ,\u0e21\u0e32\u0e25\u0e32\u0e27\u0e35",
+        "\u0e0b\u0e2d\u0e21\u0e1a\u0e32"
     ],
     "name:tum_x_preferred":[
         "Zomba"
@@ -189,9 +205,13 @@
         "\u0632\u0648\u0645\u0628\u0627"
     ],
     "name:urd_x_variant":[
-        "\u0632\u0648\u0645\u0628\u0627 \u060c \u0645\u0627\u0644\u0627\u0648\u06cc"
+        "\u0632\u0648\u0645\u0628\u0627 \u060c \u0645\u0627\u0644\u0627\u0648\u06cc",
+        "\u0632\u0648\u0645\u0628\u0627 "
     ],
     "name:uzb_x_preferred":[
+        "Zomba"
+    ],
+    "name:vec_x_preferred":[
         "Zomba"
     ],
     "name:vie_x_preferred":[
@@ -199,6 +219,9 @@
     ],
     "name:zho_x_preferred":[
         "\u677e\u5df4"
+    ],
+    "name:zul_x_preferred":[
+        "Zomba"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -340,7 +363,7 @@
         }
     ],
     "wof:id":421168777,
-    "wof:lastmodified":1636497489,
+    "wof:lastmodified":1690846536,
     "wof:name":"Zomba",
     "wof:parent_id":1108784765,
     "wof:placetype":"locality",

--- a/data/421/168/781/421168781.geojson
+++ b/data/421/168/781/421168781.geojson
@@ -28,14 +28,29 @@
     "name:ara_x_preferred":[
         "\u0644\u064a\u0644\u0648\u0646\u063a\u0648\u064a"
     ],
+    "name:arg_x_preferred":[
+        "Lilongwe"
+    ],
+    "name:ary_x_preferred":[
+        "\u0644\u064a\u0644\u0648\u0646\u06ad\u0648\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0644\u064a\u0644\u0648\u0646\u062c\u0648\u0649"
+    ],
     "name:ast_x_preferred":[
         "Lilong\u00fce"
+    ],
+    "name:avk_x_preferred":[
+        "Lilongwe"
     ],
     "name:azb_x_preferred":[
         "\u0644\u06cc\u0644\u0648\u0646\u06af\u0648\u0647"
     ],
     "name:aze_x_preferred":[
         "Lilonqve"
+    ],
+    "name:ban_x_preferred":[
+        "Lilongwe"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041b\u0456\u043b\u043e\u043d\u0433\u0432\u044d"
@@ -45,6 +60,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09b2\u09bf\u09b2\u0982\u09ac\u09c7"
+    ],
+    "name:ben_x_variant":[
+        "\u09b2\u09bf\u09b2\u0982\u0997\u09c1\u09af\u09bc\u09c7"
     ],
     "name:bod_x_preferred":[
         "\u0f63\u0f72\u0f0b\u0f63\u0f7c\u0f44\u0f0b\u0f40\u0f74\u0f60\u0f7a\u0f0d"
@@ -211,6 +229,9 @@
     "name:lav_x_preferred":[
         "Lilongve"
     ],
+    "name:lfn_x_preferred":[
+        "Lilongwe"
+    ],
     "name:lij_x_preferred":[
         "Lilongwe"
     ],
@@ -223,11 +244,17 @@
     "name:ltz_x_preferred":[
         "Lilongwe"
     ],
+    "name:lug_x_preferred":[
+        "Lilongwe"
+    ],
     "name:mal_x_preferred":[
         "\u0d32\u0d3f\u0d32\u0d4b\u0d7b\u0d17\u0d4d\u0d35\u0d47"
     ],
     "name:mar_x_preferred":[
         "\u0932\u093f\u0932\u093e\u0901\u0917\u094d\u0935\u0947"
+    ],
+    "name:mdf_x_preferred":[
+        "\u041b\u0438\u043b\u043e\u043d\u0433\u0432\u044d"
     ],
     "name:mkd_x_preferred":[
         "\u041b\u0438\u043b\u043e\u043d\u0433\u0432\u0435"
@@ -240,6 +267,9 @@
     ],
     "name:msa_x_preferred":[
         "Lilongwe"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0644\u06cc\u0644\u0648\u0646\u06af\u0648\u0647"
     ],
     "name:nah_x_preferred":[
         "Lilonhue"
@@ -271,6 +301,9 @@
     "name:oci_x_preferred":[
         "Lilongwe"
     ],
+    "name:olo_x_preferred":[
+        "Lilongve"
+    ],
     "name:oss_x_preferred":[
         "\u041b\u0438\u043b\u043e\u043d\u0433\u0432\u0435"
     ],
@@ -291,6 +324,9 @@
     ],
     "name:por_x_preferred":[
         "Lilongwe"
+    ],
+    "name:por_x_variant":[
+        "Lilongu\u00e9"
     ],
     "name:pus_x_preferred":[
         "\u0644\u06cc\u0644\u0648\u0646\u06ab\u0648\u0647"
@@ -316,6 +352,9 @@
     "name:slv_x_preferred":[
         "Lilongwe"
     ],
+    "name:smn_x_preferred":[
+        "Lilongwe"
+    ],
     "name:sna_x_preferred":[
         "Lilongwe"
     ],
@@ -329,6 +368,9 @@
         "Lilong\u00fce"
     ],
     "name:sqi_x_preferred":[
+        "Lilongwe"
+    ],
+    "name:srd_x_preferred":[
         "Lilongwe"
     ],
     "name:srp_x_preferred":[
@@ -408,6 +450,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5229\u9686\u572d"
+    ],
+    "name:zul_x_preferred":[
+        "Lilongwe"
     ],
     "ne:ADM0CAP":1.0,
     "ne:ADM0NAME":"Malawi",
@@ -557,7 +602,7 @@
         }
     ],
     "wof:id":421168781,
-    "wof:lastmodified":1607390888,
+    "wof:lastmodified":1690846536,
     "wof:name":"Lilongwe",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/169/727/421169727.geojson
+++ b/data/421/169/727/421169727.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Chikwawa"
+    ],
     "name:ceb_x_preferred":[
         "Chikwawa"
     ],
@@ -53,6 +56,9 @@
     "name:ron_x_preferred":[
         "Chikwawa"
     ],
+    "name:swa_x_preferred":[
+        "Chikwawa"
+    ],
     "name:swe_x_preferred":[
         "Chikwawa"
     ],
@@ -61,6 +67,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5947\u5938\u74e6"
+    ],
+    "name:zul_x_preferred":[
+        "Chikwawa"
     ],
     "qs:gn_country":"MW",
     "qs:gn_fcode":"PPLA2",
@@ -108,7 +117,7 @@
         }
     ],
     "wof:id":421169727,
-    "wof:lastmodified":1636497490,
+    "wof:lastmodified":1690846537,
     "wof:name":"Chikwawa",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/170/755/421170755.geojson
+++ b/data/421/170/755/421170755.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":9.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Rumphi"
+    ],
     "name:azb_x_preferred":[
         "\u0631\u0627\u0645\u0641\u06cc"
     ],
@@ -31,6 +34,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0631\u0627\u0645\u0641\u06cc"
+    ],
+    "name:fin_x_preferred":[
+        "Rumphi"
     ],
     "name:fra_x_preferred":[
         "Rumphi"
@@ -59,7 +65,16 @@
     "name:ron_x_preferred":[
         "Rumphi"
     ],
+    "name:rus_x_preferred":[
+        "\u0420\u0443\u043c\u043f\u0438"
+    ],
+    "name:swa_x_preferred":[
+        "Rumphi"
+    ],
     "name:swe_x_preferred":[
+        "Rumphi"
+    ],
+    "name:tum_x_preferred":[
         "Rumphi"
     ],
     "name:tur_x_preferred":[
@@ -70,6 +85,9 @@
     ],
     "name:zho_x_preferred":[
         "\u502b\u6bd4"
+    ],
+    "name:zul_x_preferred":[
+        "Rumphi"
     ],
     "qs:gn_country":"MW",
     "qs:gn_fcode":"PPLA2",
@@ -117,7 +135,7 @@
         }
     ],
     "wof:id":421170755,
-    "wof:lastmodified":1636497493,
+    "wof:lastmodified":1690846541,
     "wof:name":"Rumphi",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/170/773/421170773.geojson
+++ b/data/421/170/773/421170773.geojson
@@ -20,7 +20,13 @@
     "name:azb_x_preferred":[
         "\u062f\u0648\u0648\u0627"
     ],
+    "name:cat_x_preferred":[
+        "Dowa"
+    ],
     "name:ceb_x_preferred":[
+        "Dowa"
+    ],
+    "name:dan_x_preferred":[
         "Dowa"
     ],
     "name:deu_x_preferred":[
@@ -59,6 +65,9 @@
     "name:por_x_preferred":[
         "Dowa"
     ],
+    "name:swa_x_preferred":[
+        "Dowa"
+    ],
     "name:swe_x_preferred":[
         "Dowa"
     ],
@@ -67,6 +76,9 @@
     ],
     "name:zho_x_preferred":[
         "\u591a\u74e6"
+    ],
+    "name:zul_x_preferred":[
+        "Dowa"
     ],
     "qs:gn_country":"MW",
     "qs:gn_fcode":"PPLA2",
@@ -110,7 +122,7 @@
         }
     ],
     "wof:id":421170773,
-    "wof:lastmodified":1636497493,
+    "wof:lastmodified":1690846541,
     "wof:name":"Dowa",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/173/161/421173161.geojson
+++ b/data/421/173/161/421173161.geojson
@@ -17,8 +17,14 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Chipoka"
+    ],
     "name:azb_x_preferred":[
         "\u0686\u06cc\u067e\u0648\u06a9\u0627"
+    ],
+    "name:ceb_x_preferred":[
+        "Chipoka"
     ],
     "name:deu_x_preferred":[
         "Chipoka"
@@ -47,7 +53,16 @@
     "name:nya_x_preferred":[
         "Chipoka"
     ],
+    "name:pol_x_preferred":[
+        "Chipoka"
+    ],
     "name:spa_x_preferred":[
+        "Chipoka"
+    ],
+    "name:swa_x_preferred":[
+        "Chipoka"
+    ],
+    "name:swe_x_preferred":[
         "Chipoka"
     ],
     "name:tum_x_preferred":[
@@ -58,6 +73,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5947\u6ce2\u5361"
+    ],
+    "name:zul_x_preferred":[
+        "Chipoka"
     ],
     "qs:gn_country":"MW",
     "qs:gn_fcode":"PPL",
@@ -105,7 +123,7 @@
         }
     ],
     "wof:id":421173161,
-    "wof:lastmodified":1566612564,
+    "wof:lastmodified":1690846538,
     "wof:name":"Chipoka",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/173/165/421173165.geojson
+++ b/data/421/173/165/421173165.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u062e\u0644\u064a\u062c \u0646\u062e\u0627\u062a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062e\u0644\u064a\u062c \u0646\u062e\u0627\u062a\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Nkhata Bay"
+    ],
     "name:azb_x_preferred":[
         "\u0646\u06a9\u0647\u0627\u062a\u0627 \u0628\u0627\u06cc"
     ],
@@ -89,7 +95,13 @@
     "name:ron_x_preferred":[
         "Nkhata Bay"
     ],
+    "name:rus_x_preferred":[
+        "\u041d\u043a\u0430\u0442\u0430-\u0411\u0435\u0439"
+    ],
     "name:spa_x_preferred":[
+        "Nkhata Bay"
+    ],
+    "name:swa_x_preferred":[
         "Nkhata Bay"
     ],
     "name:swe_x_preferred":[
@@ -112,6 +124,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6069\u5361\u5854\u7063"
+    ],
+    "name:zul_x_preferred":[
+        "Nkhata Bay"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -251,7 +266,7 @@
         }
     ],
     "wof:id":421173165,
-    "wof:lastmodified":1636497491,
+    "wof:lastmodified":1690846539,
     "wof:name":"Nkhata Bay",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/173/167/421173167.geojson
+++ b/data/421/173/167/421173167.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u0644\u0627\u0646\u062c\u064a"
     ],
+    "name:ast_x_preferred":[
+        "Mulanje"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0648\u0644\u0627\u0646\u062c\u0647"
     ],
@@ -89,6 +92,9 @@
     "name:spa_x_preferred":[
         "Mulanje"
     ],
+    "name:swa_x_preferred":[
+        "Mulanje"
+    ],
     "name:swe_x_preferred":[
         "Mulanje"
     ],
@@ -112,6 +118,9 @@
     ],
     "name:zho_x_variant":[
         "\u5947\u6ce2\u5361"
+    ],
+    "name:zul_x_preferred":[
+        "Mulanje"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -251,7 +260,7 @@
         }
     ],
     "wof:id":421173167,
-    "wof:lastmodified":1636497491,
+    "wof:lastmodified":1690846538,
     "wof:name":"Mulanje",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/173/169/421173169.geojson
+++ b/data/421/173/169/421173169.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0628\u0644\u0627\u0646\u062a\u0627\u064a\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0644\u0627\u0646\u062a\u0627\u064a\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Blantyre"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0644\u0627\u0646\u062a\u0627\u06cc\u0631"
     ],
@@ -35,6 +41,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0411\u043b\u0430\u043d\u0442\u0430\u0439\u0440"
     ],
+    "name:bel_x_variant":[
+        "\u0411\u043b\u0430\u043d\u0442\u0430\u0439\u0440"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09cd\u09b2\u09be\u09a8\u09a4\u09bf\u09b0\u09c7"
     ],
@@ -46,6 +55,9 @@
     ],
     "name:bul_x_variant":[
         "\u0411\u043b\u0430\u043d\u0442\u0430\u0439\u0440"
+    ],
+    "name:cat_x_preferred":[
+        "Blantyre"
     ],
     "name:ceb_x_preferred":[
         "Blantyre"
@@ -110,6 +122,9 @@
     "name:hun_x_preferred":[
         "Blantyre"
     ],
+    "name:hye_x_preferred":[
+        "\u0532\u056c\u0561\u0576\u057f\u0561\u0575\u0580"
+    ],
     "name:ind_x_preferred":[
         "Blantyre"
     ],
@@ -148,6 +163,9 @@
     ],
     "name:mar_x_preferred":[
         "\u092c\u094d\u0932\u0901\u091f\u093e\u092f\u0930"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0411\u043b\u0430\u043d\u0442\u0430\u0439\u0440"
     ],
     "name:msa_x_preferred":[
         "Blantyre"
@@ -194,6 +212,9 @@
     "name:srp_x_preferred":[
         "\u0411\u043b\u0430\u043d\u0442\u0430\u0458\u0435\u0440"
     ],
+    "name:swa_x_preferred":[
+        "Blantyre"
+    ],
     "name:swe_x_preferred":[
         "Blantyre"
     ],
@@ -224,17 +245,26 @@
     "name:uzb_x_preferred":[
         "Blantayrlimbe"
     ],
+    "name:vec_x_preferred":[
+        "Blantyre"
+    ],
     "name:vie_x_preferred":[
         "Blantyre"
     ],
     "name:war_x_preferred":[
         "Blantyre-Limbe"
     ],
+    "name:wuu_x_preferred":[
+        "\u5e03\u5170\u592a\u5c14"
+    ],
     "name:yue_x_preferred":[
         "\u5e03\u862d\u592a\u723e"
     ],
     "name:zho_x_preferred":[
         "\u5e03\u5170\u592a\u5c14"
+    ],
+    "name:zul_x_preferred":[
+        "Blantyre"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -378,7 +408,7 @@
         }
     ],
     "wof:id":421173169,
-    "wof:lastmodified":1566612564,
+    "wof:lastmodified":1690846539,
     "wof:name":"Blantyre",
     "wof:parent_id":1108784761,
     "wof:placetype":"locality",

--- a/data/421/174/673/421174673.geojson
+++ b/data/421/174/673/421174673.geojson
@@ -98,7 +98,13 @@
     "name:ron_x_preferred":[
         "Nkhotakota"
     ],
+    "name:rus_x_preferred":[
+        "\u041d\u0445\u043e\u0442\u0430\u043a\u043e\u0442\u0430"
+    ],
     "name:spa_x_preferred":[
+        "Nkhotakota"
+    ],
+    "name:swa_x_preferred":[
         "Nkhotakota"
     ],
     "name:swe_x_preferred":[
@@ -124,6 +130,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6069\u79d1\u5854\u79d1\u5854"
+    ],
+    "name:zul_x_preferred":[
+        "Nkhotakota"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -260,7 +269,7 @@
         }
     ],
     "wof:id":421174673,
-    "wof:lastmodified":1636497491,
+    "wof:lastmodified":1690846538,
     "wof:name":"Nkhotakota",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/182/029/421182029.geojson
+++ b/data/421/182/029/421182029.geojson
@@ -68,6 +68,9 @@
     "name:und_x_variant":[
         "Livingstonia Mission"
     ],
+    "name:zul_x_preferred":[
+        "Livingstonia"
+    ],
     "qs:gn_country":"MW",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":927856,
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421182029,
-    "wof:lastmodified":1566612566,
+    "wof:lastmodified":1690846541,
     "wof:name":"Livingstonia",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/187/477/421187477.geojson
+++ b/data/421/187/477/421187477.geojson
@@ -68,6 +68,9 @@
     "name:rus_x_preferred":[
         "\u041c\u043e\u043d\u00ad\u043a\u0438-\u0411\u0435\u0439"
     ],
+    "name:swa_x_preferred":[
+        "Monkey Bay"
+    ],
     "name:swe_x_preferred":[
         "Monkey Bay"
     ],
@@ -79,6 +82,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7334\u5b50\u7063"
+    ],
+    "name:zul_x_preferred":[
+        "Monkey Bay"
     ],
     "qs:gn_country":"MW",
     "qs:gn_fcode":"PPL",
@@ -124,7 +130,7 @@
         }
     ],
     "wof:id":421187477,
-    "wof:lastmodified":1566612563,
+    "wof:lastmodified":1690846538,
     "wof:name":"Monkey Bay",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/195/229/421195229.geojson
+++ b/data/421/195/229/421195229.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0646\u063a\u0648\u062a\u0634\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0646\u062c\u0648\u062a\u0634\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Mangochi"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0627\u0646\u0642\u0648\u0686\u06cc"
     ],
@@ -49,6 +55,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05de\u05d0\u05e0\u05d2\u05d5\u05e7\u05d9"
+    ],
+    "name:heb_x_variant":[
+        "\u05de\u05e0\u05d2\u05d5\u05e6'\u05d9"
     ],
     "name:hin_x_preferred":[
         "\u092e\u0902\u0917\u094b\u091a\u093f"
@@ -95,6 +104,9 @@
     "name:spa_x_preferred":[
         "Mangochi"
     ],
+    "name:swa_x_preferred":[
+        "Mangochi"
+    ],
     "name:swe_x_preferred":[
         "Mangochi"
     ],
@@ -115,6 +127,9 @@
     ],
     "name:zho_x_preferred":[
         "\u66fc\u6208\u5207"
+    ],
+    "name:zul_x_preferred":[
+        "Mangochi"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -254,7 +269,7 @@
         }
     ],
     "wof:id":421195229,
-    "wof:lastmodified":1636497490,
+    "wof:lastmodified":1690846537,
     "wof:name":"Mangochi",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/196/735/421196735.geojson
+++ b/data/421/196/735/421196735.geojson
@@ -47,10 +47,19 @@
     "name:nya_x_preferred":[
         "Mponela"
     ],
+    "name:pol_x_preferred":[
+        "Mponela"
+    ],
+    "name:swa_x_preferred":[
+        "Mponela"
+    ],
     "name:swe_x_preferred":[
         "Mponela"
     ],
     "name:tur_x_preferred":[
+        "Mponela"
+    ],
+    "name:zul_x_preferred":[
         "Mponela"
     ],
     "qs:gn_country":"MW",
@@ -97,7 +106,7 @@
         }
     ],
     "wof:id":421196735,
-    "wof:lastmodified":1566612565,
+    "wof:lastmodified":1690846539,
     "wof:name":"Mponela",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/197/379/421197379.geojson
+++ b/data/421/197/379/421197379.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":10.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Luchenza"
+    ],
     "name:azb_x_preferred":[
         "\u0644\u0648\u0686\u0646\u0632\u0627"
     ],
@@ -59,6 +62,9 @@
     "name:rus_x_preferred":[
         "\u041b\u0443\u0447\u0435\u043d\u0437\u0430"
     ],
+    "name:swa_x_preferred":[
+        "Luchenza"
+    ],
     "name:swe_x_preferred":[
         "Luchenza"
     ],
@@ -70,6 +76,9 @@
     ],
     "name:zho_x_preferred":[
         "\u76e7\u7434\u624e"
+    ],
+    "name:zul_x_preferred":[
+        "Luchenza"
     ],
     "qs:gn_country":"MW",
     "qs:gn_fcode":"PPL",
@@ -117,7 +126,7 @@
         }
     ],
     "wof:id":421197379,
-    "wof:lastmodified":1566612565,
+    "wof:lastmodified":1690846540,
     "wof:name":"Luchenza",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/198/535/421198535.geojson
+++ b/data/421/198/535/421198535.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0634\u064a\u062a\u064a\u0628\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u064a\u062a\u064a\u0628\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Chitipa"
+    ],
     "name:azb_x_preferred":[
         "\u0686\u06cc\u062a\u06cc\u067e\u0627"
     ],
@@ -89,11 +95,17 @@
     "name:ron_x_preferred":[
         "Chitipa"
     ],
+    "name:rus_x_preferred":[
+        "\u0427\u0438\u0442\u0438\u043f\u0430"
+    ],
     "name:spa_x_preferred":[
         "Chitipa"
     ],
     "name:srp_x_preferred":[
         "\u0427\u0438\u0442\u0438\u043f\u0430"
+    ],
+    "name:swa_x_preferred":[
+        "Chitipa"
     ],
     "name:swe_x_preferred":[
         "Chitipa"
@@ -115,6 +127,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5947\u8482\u5e15"
+    ],
+    "name:zul_x_preferred":[
+        "Chitipa"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -254,7 +269,7 @@
         }
     ],
     "wof:id":421198535,
-    "wof:lastmodified":1636497491,
+    "wof:lastmodified":1690846539,
     "wof:name":"Chitipa",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/198/537/421198537.geojson
+++ b/data/421/198/537/421198537.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062d\u064a \u0646\u062a\u0634\u064a\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u062d\u0649 \u0646\u062a\u0634\u064a\u0648"
+    ],
     "name:azb_x_preferred":[
         "\u0646\u062a\u0686\u0626\u0648"
     ],
@@ -86,7 +89,13 @@
     "name:spa_x_preferred":[
         "Ntcheu"
     ],
+    "name:swa_x_preferred":[
+        "Ntcheu"
+    ],
     "name:swe_x_preferred":[
+        "Ntcheu"
+    ],
+    "name:tum_x_preferred":[
         "Ntcheu"
     ],
     "name:tur_x_preferred":[
@@ -106,6 +115,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6069\u5f7b\u4e4c"
+    ],
+    "name:zul_x_preferred":[
+        "Ntcheu"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -242,7 +254,7 @@
         }
     ],
     "wof:id":421198537,
-    "wof:lastmodified":1636497491,
+    "wof:lastmodified":1690846539,
     "wof:name":"Ntcheu",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/199/031/421199031.geojson
+++ b/data/421/199/031/421199031.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062d\u064a \u0645\u0632\u064a\u0645\u0628\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062d\u0649 \u0645\u0632\u064a\u0645\u0628\u0627"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0632\u06cc\u0645\u0628\u0627"
     ],
@@ -52,6 +55,9 @@
     ],
     "name:hun_x_preferred":[
         "Mzimba"
+    ],
+    "name:hye_x_preferred":[
+        "\u0544\u0566\u056b\u0574\u0562\u0561"
     ],
     "name:ind_x_preferred":[
         "Mzimba"
@@ -92,6 +98,9 @@
     "name:spa_x_preferred":[
         "Mzimba"
     ],
+    "name:swa_x_preferred":[
+        "Mzimba"
+    ],
     "name:swe_x_preferred":[
         "Mzimba"
     ],
@@ -112,6 +121,9 @@
     ],
     "name:zho_x_preferred":[
         "\u59c6\u6d25\u5df4"
+    ],
+    "name:zul_x_preferred":[
+        "Mzimba"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -248,7 +260,7 @@
         }
     ],
     "wof:id":421199031,
-    "wof:lastmodified":1636497492,
+    "wof:lastmodified":1690846540,
     "wof:name":"Mzimba",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/200/259/421200259.geojson
+++ b/data/421/200/259/421200259.geojson
@@ -80,6 +80,9 @@
     "name:spa_x_preferred":[
         "Mwanza"
     ],
+    "name:swa_x_preferred":[
+        "Mwanza"
+    ],
     "name:swe_x_preferred":[
         "Mwanza"
     ],
@@ -237,7 +240,7 @@
         }
     ],
     "wof:id":421200259,
-    "wof:lastmodified":1636497492,
+    "wof:lastmodified":1690846540,
     "wof:name":"Mwanza",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/201/075/421201075.geojson
+++ b/data/421/201/075/421201075.geojson
@@ -92,6 +92,9 @@
     "name:spa_x_preferred":[
         "Salima"
     ],
+    "name:swa_x_preferred":[
+        "Salima"
+    ],
     "name:swe_x_preferred":[
         "Salima"
     ],
@@ -109,6 +112,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8428\u5229\u9a6c"
+    ],
+    "name:zul_x_preferred":[
+        "Salima"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -245,7 +251,7 @@
         }
     ],
     "wof:id":421201075,
-    "wof:lastmodified":1636497492,
+    "wof:lastmodified":1690846541,
     "wof:name":"Salima",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/201/083/421201083.geojson
+++ b/data/421/201/083/421201083.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0631\u064a\u0641 \u0643\u0627\u0631\u0648\u0646\u062c\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0631\u064a\u0641 \u0643\u0627\u0631\u0648\u0646\u062c\u0627"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0627\u0631\u0648\u0646\u0642\u0627"
     ],
@@ -52,6 +55,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05e7\u05d0\u05e8\u05d5\u05e0\u05d2\u05d4"
+    ],
+    "name:heb_x_variant":[
+        "\u05e7\u05e8\u05d5\u05e0\u05d2\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u0915\u093e\u0930\u094b\u0902\u0917\u093e"
@@ -95,6 +101,9 @@
     "name:spa_x_preferred":[
         "Karonga"
     ],
+    "name:swa_x_preferred":[
+        "Karonga"
+    ],
     "name:swe_x_preferred":[
         "Karonga"
     ],
@@ -115,6 +124,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u9f99\u52a0"
+    ],
+    "name:zul_x_preferred":[
+        "Karonga"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -254,7 +266,7 @@
         }
     ],
     "wof:id":421201083,
-    "wof:lastmodified":1636497492,
+    "wof:lastmodified":1690846540,
     "wof:name":"Karonga",
     "wof:parent_id":1108784757,
     "wof:placetype":"locality",

--- a/data/421/201/085/421201085.geojson
+++ b/data/421/201/085/421201085.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0634\u064a\u0646\u062c\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0634\u064a\u0646\u062c\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0686\u06cc\u0646\u062c\u06cc"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0645\u0686\u06cc\u0646\u062c\u06cc"
+    ],
+    "name:fin_x_preferred":[
+        "Mchinji"
     ],
     "name:fra_x_preferred":[
         "Mchinji"
@@ -89,6 +95,9 @@
     "name:spa_x_preferred":[
         "Mchinji"
     ],
+    "name:swa_x_preferred":[
+        "Mchinji"
+    ],
     "name:swe_x_preferred":[
         "Mchinji"
     ],
@@ -109,6 +118,9 @@
     ],
     "name:zho_x_preferred":[
         "\u59c6\u94a6\u5409"
+    ],
+    "name:zul_x_preferred":[
+        "Mchinji"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -245,7 +257,7 @@
         }
     ],
     "wof:id":421201085,
-    "wof:lastmodified":1636497492,
+    "wof:lastmodified":1690846540,
     "wof:name":"Mchinji",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/201/469/421201469.geojson
+++ b/data/421/201/469/421201469.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0644\u064a\u0645\u0628\u0647"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u064a\u0645\u0628\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Limbe"
+    ],
     "name:azb_x_preferred":[
         "\u0644\u06cc\u0645\u0628\u0647"
     ],
@@ -137,6 +143,9 @@
     "name:zho_x_preferred":[
         "\u6797\u8d1d"
     ],
+    "name:zul_x_preferred":[
+        "Limbe"
+    ],
     "qs:gn_country":"MW",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":927955,
@@ -182,7 +191,7 @@
         }
     ],
     "wof:id":421201469,
-    "wof:lastmodified":1636497492,
+    "wof:lastmodified":1690846541,
     "wof:name":"Limbe",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/203/055/421203055.geojson
+++ b/data/421/203/055/421203055.geojson
@@ -62,6 +62,9 @@
     "name:ron_x_preferred":[
         "Ntchisi"
     ],
+    "name:swa_x_preferred":[
+        "Ntchisi"
+    ],
     "name:swe_x_preferred":[
         "Ntchisi"
     ],
@@ -73,6 +76,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6069\u5947\u65af"
+    ],
+    "name:zul_x_preferred":[
+        "Ntchisi"
     ],
     "qs:gn_country":"MW",
     "qs:gn_fcode":"PPLA2",
@@ -117,7 +123,7 @@
         }
     ],
     "wof:id":421203055,
-    "wof:lastmodified":1636497490,
+    "wof:lastmodified":1690846537,
     "wof:name":"Ntchisi",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/205/403/421205403.geojson
+++ b/data/421/205/403/421205403.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0634\u064a\u0631\u0627\u062f\u0632\u0648\u0644\u0648"
     ],
+    "name:ast_x_preferred":[
+        "Chiradzulu"
+    ],
     "name:ben_x_preferred":[
         "\u099a\u09bf\u09b0\u09be\u09a6\u099c\u09c1\u09b2\u09c1"
     ],
@@ -103,6 +106,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5947\u62c9\u7956\u76e7"
+    ],
+    "name:zul_x_preferred":[
+        "Chiradzulu"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
@@ -242,7 +248,7 @@
         }
     ],
     "wof:id":421205403,
-    "wof:lastmodified":1636497491,
+    "wof:lastmodified":1690846538,
     "wof:name":"Chiradzulu",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/323/83/85632383.geojson
+++ b/data/856/323/83/85632383.geojson
@@ -25,6 +25,9 @@
     "mz:is_current":1,
     "mz:max_zoom":9.0,
     "mz:min_zoom":4.0,
+    "name:abk_x_preferred":[
+        "\u041c\u0430\u043b\u0430\u0432\u0438"
+    ],
     "name:ace_x_preferred":[
         "Malawi"
     ],
@@ -39,6 +42,15 @@
     ],
     "name:amh_x_preferred":[
         "\u121b\u120b\u12ca"
+    ],
+    "name:ami_x_preferred":[
+        "Malawi"
+    ],
+    "name:ang_x_preferred":[
+        "Malawi"
+    ],
+    "name:anp_x_preferred":[
+        "\u092e\u093e\u0932\u093e\u0935\u0940"
     ],
     "name:ara_x_preferred":[
         "\u0645\u0627\u0644\u0627\u0648\u064a"
@@ -64,6 +76,9 @@
     "name:ast_x_variant":[
         "Malaui"
     ],
+    "name:avk_x_preferred":[
+        "Malawia"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0627\u0644\u0627\u0648\u06cc"
     ],
@@ -79,6 +94,9 @@
     "name:ban_x_preferred":[
         "Malawi"
     ],
+    "name:bar_x_preferred":[
+        "Malawi"
+    ],
     "name:bcl_x_preferred":[
         "Malawi"
     ],
@@ -90,6 +108,9 @@
     ],
     "name:bho_x_preferred":[
         "\u092e\u0932\u093e\u0935\u0940"
+    ],
+    "name:bis_x_preferred":[
+        "Malawi"
     ],
     "name:bjn_x_preferred":[
         "Malawi"
@@ -142,10 +163,16 @@
     "name:cor_x_preferred":[
         "Malawi"
     ],
+    "name:cos_x_preferred":[
+        "Malaui"
+    ],
     "name:crh_x_preferred":[
         "Malavi"
     ],
     "name:cym_x_preferred":[
+        "Malawi"
+    ],
+    "name:dag_x_preferred":[
         "Malawi"
     ],
     "name:dan_x_preferred":[
@@ -238,6 +265,9 @@
     "name:ful_x_preferred":[
         "Malaawi"
     ],
+    "name:ful_x_variant":[
+        "Malawi"
+    ],
     "name:gag_x_preferred":[
         "Malavi"
     ],
@@ -259,6 +289,9 @@
     "name:glv_x_preferred":[
         "Malawi"
     ],
+    "name:gpe_x_preferred":[
+        "Malawi"
+    ],
     "name:grn_x_preferred":[
         "Mal\u00e1ui"
     ],
@@ -270,6 +303,9 @@
     ],
     "name:guj_x_variant":[
         "\u0aae\u0ab2\u0abe\u0ab5\u0ac0"
+    ],
+    "name:gur_x_preferred":[
+        "Malawi"
     ],
     "name:hak_x_preferred":[
         "Malawi"
@@ -417,6 +453,9 @@
     "name:lit_x_preferred":[
         "Malavis"
     ],
+    "name:lld_x_preferred":[
+        "Malaui"
+    ],
     "name:lmo_x_preferred":[
         "Malawi"
     ],
@@ -444,6 +483,12 @@
     "name:mar_x_preferred":[
         "\u092e\u0932\u093e\u0935\u0940"
     ],
+    "name:mdf_x_preferred":[
+        "\u041c\u0430\u043b\u0430\u0432\u0438"
+    ],
+    "name:mhr_x_preferred":[
+        "\u041c\u0430\u043b\u0430\u0432\u0438"
+    ],
     "name:min_x_preferred":[
         "Malawi"
     ],
@@ -458,6 +503,9 @@
     ],
     "name:mlt_x_preferred":[
         "Malawi"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc3\uabe5\uabc2\uabe5\uabcb\uabe4"
     ],
     "name:mon_x_preferred":[
         "\u041c\u0430\u043b\u0430\u0432\u0438"
@@ -481,6 +529,9 @@
         "Malahui"
     ],
     "name:nan_x_preferred":[
+        "Malawi"
+    ],
+    "name:nau_x_preferred":[
         "Malawi"
     ],
     "name:nav_x_preferred":[
@@ -610,6 +661,9 @@
     "name:sgs_x_preferred":[
         "Malavis"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1019\u1083\u1087\u101c\u1083\u1087\u101d\u102e\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0db8\u0dbd\u0dcf\u0dc0\u0dd2\u0dba"
     ],
@@ -623,8 +677,14 @@
     "name:sme_x_preferred":[
         "Malawi"
     ],
+    "name:smn_x_preferred":[
+        "Malawi"
+    ],
     "name:smo_x_preferred":[
         "Malawi"
+    ],
+    "name:sms_x_preferred":[
+        "Malaaw"
     ],
     "name:sna_x_preferred":[
         "Malawi"
@@ -689,6 +749,9 @@
     "name:tat_x_preferred":[
         "\u041c\u0430\u043b\u0430\u0432\u0438"
     ],
+    "name:tay_x_preferred":[
+        "Malawi"
+    ],
     "name:tel_x_preferred":[
         "\u0c2e\u0c3e\u0c32\u0c3e\u0c35\u0c3f"
     ],
@@ -710,8 +773,14 @@
     "name:tir_x_preferred":[
         "\u121b\u120b\u12ca"
     ],
+    "name:tok_x_preferred":[
+        "ma Malawi"
+    ],
     "name:ton_x_preferred":[
         "Malaui"
+    ],
+    "name:trv_x_preferred":[
+        "Malawi"
     ],
     "name:tso_x_preferred":[
         "Malawi"
@@ -721,6 +790,9 @@
     ],
     "name:tum_x_preferred":[
         "Malawi"
+    ],
+    "name:tum_x_variant":[
+        "Mala\u0175i"
     ],
     "name:tur_x_preferred":[
         "Malavi"
@@ -759,6 +831,9 @@
     "name:vie_x_variant":[
         "Ma-la-uy",
         "Ma-la-uy (Malawi)"
+    ],
+    "name:vls_x_preferred":[
+        "Malawi"
     ],
     "name:vol_x_preferred":[
         "Malaviy\u00e4n"
@@ -1035,7 +1110,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1617827450,
+    "wof:lastmodified":1690846533,
     "wof:name":"Malawi",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/890/422/339/890422339.geojson
+++ b/data/890/422/339/890422339.geojson
@@ -39,6 +39,9 @@
     "name:bul_x_preferred":[
         "\u0427\u0438\u043a\u0443\u0430\u0443\u0430"
     ],
+    "name:cat_x_preferred":[
+        "Chikwawa"
+    ],
     "name:ceb_x_preferred":[
         "Chikwawa District"
     ],
@@ -93,6 +96,9 @@
     "name:kor_x_preferred":[
         "\uce58\ucf70\uc640 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uce58\ucf70\uc640\ud604"
+    ],
     "name:lav_x_preferred":[
         "\u010cikvavas distrikts"
     ],
@@ -104,6 +110,9 @@
     ],
     "name:msa_x_preferred":[
         "Chikwawa District"
+    ],
+    "name:nan_x_preferred":[
+        "Chikwawa Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Chikwawa"
@@ -129,6 +138,9 @@
     "name:swe_x_preferred":[
         "Chikwawa"
     ],
+    "name:tam_x_preferred":[
+        "\u0b9a\u0bbf\u0b95\u0bbf\u0bb5\u0bbe\u0bb5\u0bbe \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c1a\u0c3f\u0c15\u0c4d\u0c35\u0c3e\u0c35\u0c3e \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
     ],
@@ -152,6 +164,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5947\u514b\u74e6\u74e6\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Chikwawa District"
     ],
     "qs:name":"Chikwawa District",
     "qs:photos_9r":0,
@@ -181,7 +196,7 @@
         }
     ],
     "wof:id":890422339,
-    "wof:lastmodified":1636497493,
+    "wof:lastmodified":1690846542,
     "wof:name":"Chikwawa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/428/701/890428701.geojson
+++ b/data/890/428/701/890428701.geojson
@@ -93,6 +93,9 @@
     "name:kor_x_preferred":[
         "\ud314\ub86c\ubca0 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ud314\ub86c\ubca0\ud604"
+    ],
     "name:lav_x_preferred":[
         "Falombes distrikts"
     ],
@@ -104,6 +107,9 @@
     ],
     "name:msa_x_preferred":[
         "Phalombe District"
+    ],
+    "name:nan_x_preferred":[
+        "Phalombe Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Phalombe"
@@ -132,6 +138,9 @@
     "name:swe_x_preferred":[
         "Phalombe"
     ],
+    "name:tam_x_preferred":[
+        "\u0baa\u0bbe\u0bb2\u0bae\u0bcd\u0baa\u0bc7 \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c2b\u0c3e\u0c32\u0c4b\u0c02\u0c2c\u0c47 \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
     ],
@@ -155,6 +164,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6cd5\u9686\u8c9d\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Phalombe District"
     ],
     "qs:name":"Phalombe District",
     "qs:photos_9r":0,
@@ -184,7 +196,7 @@
         }
     ],
     "wof:id":890428701,
-    "wof:lastmodified":1636497496,
+    "wof:lastmodified":1690846547,
     "wof:name":"Phalombe",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/430/545/890430545.geojson
+++ b/data/890/430/545/890430545.geojson
@@ -106,6 +106,9 @@
     "name:zho_tw_x_preferred":[
         "\u99ac\u6b3d\u52a0"
     ],
+    "name:zul_x_preferred":[
+        "Machinga"
+    ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Malawi",
     "ne:ADM0_A3":"MWI",
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":890430545,
-    "wof:lastmodified":1636497493,
+    "wof:lastmodified":1690846543,
     "wof:name":"Machinga",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/430/565/890430565.geojson
+++ b/data/890/430/565/890430565.geojson
@@ -93,6 +93,9 @@
     "name:kor_x_preferred":[
         "\uc740\uce58\uc2dc \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uc740\uce58\uc2dc\ud604"
+    ],
     "name:lav_x_preferred":[
         "Ntsi\u010di rajons"
     ],
@@ -104,6 +107,9 @@
     ],
     "name:msa_x_preferred":[
         "Daerah Ntchisi"
+    ],
+    "name:nan_x_preferred":[
+        "Ntchisi Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Ntchisi"
@@ -129,6 +135,9 @@
     "name:swe_x_preferred":[
         "Ntchisi"
     ],
+    "name:tam_x_preferred":[
+        "\u0ba8\u0b9f\u0bcd\u0b9a\u0bbf\u0b9a\u0bbf \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c0e\u0c28\u0c4d\u0c1a\u0c3f\u0c1c\u0c3f \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
     ],
@@ -152,6 +161,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6069\u5947\u65af\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Ntchisi District"
     ],
     "qs:name":"Ntchisi District",
     "qs:photos_9r":0,
@@ -181,7 +193,7 @@
         }
     ],
     "wof:id":890430565,
-    "wof:lastmodified":1636497494,
+    "wof:lastmodified":1690846543,
     "wof:name":"Ntchisi",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/430/567/890430567.geojson
+++ b/data/890/430/567/890430567.geojson
@@ -87,6 +87,9 @@
     "name:kor_x_preferred":[
         "\uc740\uc0b0\uc81c \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uc740\uc0b0\uc81c\ud604"
+    ],
     "name:lav_x_preferred":[
         "Nsand\u017ees distrikts"
     ],
@@ -98,6 +101,9 @@
     ],
     "name:msa_x_preferred":[
         "Daerah Nsanje"
+    ],
+    "name:nan_x_preferred":[
+        "Nsanje Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Nsanje"
@@ -153,6 +159,9 @@
     "name:zho_x_preferred":[
         "\u6069\u6851\u5091\u7e23"
     ],
+    "name:zul_x_preferred":[
+        "Nsanje District"
+    ],
     "qs:name":"Nsanje District",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -181,7 +190,7 @@
         }
     ],
     "wof:id":890430567,
-    "wof:lastmodified":1636497493,
+    "wof:lastmodified":1690846542,
     "wof:name":"Nsanje",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/430/569/890430569.geojson
+++ b/data/890/430/569/890430569.geojson
@@ -93,6 +93,9 @@
     "name:kor_x_preferred":[
         "\uc740\ucf54\ud0c0\ucf54\ud0c0 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uc740\ucf54\ud0c0\ucf54\ud0c0\ud604"
+    ],
     "name:lav_x_preferred":[
         "Nkhotakotas distrikts"
     ],
@@ -104,6 +107,9 @@
     ],
     "name:msa_x_preferred":[
         "Nkhotakota District"
+    ],
+    "name:nan_x_preferred":[
+        "Nkhotakota Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Nkhotakota"
@@ -128,6 +134,9 @@
     ],
     "name:swe_x_preferred":[
         "Nkhotakota"
+    ],
+    "name:tam_x_preferred":[
+        "\u0ba8\u0bcd\u0b95\u0bb9\u0bcb\u0b9f\u0b95\u0bcb\u0b9f\u0bbe \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c28\u0c3f\u0c15\u0c4b\u0c1f\u0c3e\u0c15\u0c4b\u0c1f\u0c3e \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
@@ -155,6 +164,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6069\u79d1\u5854\u79d1\u5854\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Nkhotakota District"
     ],
     "qs:name":"Nkhotakota District",
     "qs:photos_9r":0,
@@ -184,7 +196,7 @@
         }
     ],
     "wof:id":890430569,
-    "wof:lastmodified":1636497493,
+    "wof:lastmodified":1690846542,
     "wof:name":"Nkhotakota",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/433/501/890433501.geojson
+++ b/data/890/433/501/890433501.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u062b\u064a\u0648\u0644\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u062b\u064a\u0648\u0644\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Thyolo"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u06cc\u0648\u0644\u0648"
     ],
@@ -57,6 +63,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0aa5\u0abf\u0a93\u0ab2\u0acb"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d8\u05d9\u05d5\u05dc\u05d5"
     ],
     "name:hin_x_preferred":[
         "\u0925\u093f\u092f\u094b\u0932\u094b"
@@ -121,6 +130,9 @@
     "name:spa_x_preferred":[
         "Thyolo"
     ],
+    "name:swa_x_preferred":[
+        "Thyolo"
+    ],
     "name:swe_x_preferred":[
         "Thyolo"
     ],
@@ -154,6 +166,9 @@
     "name:zho_x_preferred":[
         "\u55ac\u6d1b"
     ],
+    "name:zul_x_preferred":[
+        "Thyolo"
+    ],
     "qs:name":"Thyolo",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -185,7 +200,7 @@
         }
     ],
     "wof:id":890433501,
-    "wof:lastmodified":1636497496,
+    "wof:lastmodified":1690846547,
     "wof:name":"Thyolo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/435/513/890435513.geojson
+++ b/data/890/435/513/890435513.geojson
@@ -93,6 +93,9 @@
     "name:kor_x_preferred":[
         "\ubc1c\ub77c\uce74 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ubc1c\ub77c\uce74\ud604"
+    ],
     "name:lav_x_preferred":[
         "Balakas distrikts"
     ],
@@ -104,6 +107,9 @@
     ],
     "name:msa_x_preferred":[
         "Daerah Balaka"
+    ],
+    "name:nan_x_preferred":[
+        "Balaka Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Balaka"
@@ -159,6 +165,9 @@
     "name:zho_x_preferred":[
         "\u5df4\u62c9\u5361\u7e23"
     ],
+    "name:zul_x_preferred":[
+        "Balaka District"
+    ],
     "qs:name":"Balaka District",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -187,7 +196,7 @@
         }
     ],
     "wof:id":890435513,
-    "wof:lastmodified":1636497497,
+    "wof:lastmodified":1690846547,
     "wof:name":"Balaka",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/045/890438045.geojson
+++ b/data/890/438/045/890438045.geojson
@@ -84,6 +84,9 @@
     "name:kor_x_preferred":[
         "\uc740\uce74\ud0c0\ubca0\uc774 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uc740\uce74\ud0c0\ubca0\uc774\ud604"
+    ],
     "name:lav_x_preferred":[
         "Nkhatabejas distrikts"
     ],
@@ -95,6 +98,9 @@
     ],
     "name:msa_x_preferred":[
         "Nkhata Bay District"
+    ],
+    "name:nan_x_preferred":[
+        "Nkhata Bay Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Nkhata Bay"
@@ -120,6 +126,9 @@
     "name:srp_x_preferred":[
         "\u041d\u0445\u0430\u0442\u0430 \u0411\u0435\u0458"
     ],
+    "name:swa_x_preferred":[
+        "Wilaya ya Nkhata Bay"
+    ],
     "name:swe_x_preferred":[
         "Nkhata Bay"
     ],
@@ -131,6 +140,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e02\u0e15\u0e04\u0e2e\u0e32\u0e17\u0e32 \u0e40\u0e1a\u0e22\u0e4c"
+    ],
+    "name:tum_x_preferred":[
+        "Boma la Nkhata Bay"
     ],
     "name:tur_x_preferred":[
         "Nkhata Bay"
@@ -152,6 +164,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6069\u5361\u5854\u7063\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Nkhata Bay District"
     ],
     "qs:name":"Nkhata Bay District",
     "qs:photos_9r":0,
@@ -181,7 +196,7 @@
         }
     ],
     "wof:id":890438045,
-    "wof:lastmodified":1636497495,
+    "wof:lastmodified":1690846545,
     "wof:name":"Nkhata Bay",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/047/890438047.geojson
+++ b/data/890/438/047/890438047.geojson
@@ -36,6 +36,9 @@
     "name:bul_x_preferred":[
         "\u041d\u0442\u0447\u0435\u0443"
     ],
+    "name:cat_x_preferred":[
+        "Ncheu"
+    ],
     "name:ceb_x_preferred":[
         "Ntcheu District"
     ],
@@ -84,6 +87,9 @@
     "name:kor_x_preferred":[
         "\uc740\uccb4\uc6b0 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uc740\uccb4\uc6b0\ud604"
+    ],
     "name:lav_x_preferred":[
         "N\u010dheu distrikts"
     ],
@@ -95,6 +101,9 @@
     ],
     "name:msa_x_preferred":[
         "Ntcheu District"
+    ],
+    "name:nan_x_preferred":[
+        "Ntcheu Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Ntcheu"
@@ -119,6 +128,9 @@
     ],
     "name:swe_x_preferred":[
         "Ntcheu"
+    ],
+    "name:tam_x_preferred":[
+        "\u0ba8\u0bbf\u0b9f\u0bcd\u0b9a\u0bc7\u0b95\u0bcd\u0b95\u0bc1 \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c0e\u0c28\u0c4d\u0c1a\u0c3f\u0c2f\u0c42 \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
@@ -146,6 +158,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6069\u5fb9\u70cf\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Ntcheu District"
     ],
     "qs:name":"Ntcheu District",
     "qs:photos_9r":0,
@@ -175,7 +190,7 @@
         }
     ],
     "wof:id":890438047,
-    "wof:lastmodified":1636497494,
+    "wof:lastmodified":1690846544,
     "wof:name":"Ntcheu",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/051/890438051.geojson
+++ b/data/890/438/051/890438051.geojson
@@ -42,6 +42,9 @@
     "name:bul_x_preferred":[
         "\u041c\u0437\u0438\u043c\u0431\u0430"
     ],
+    "name:cat_x_preferred":[
+        "Mzimba"
+    ],
     "name:ceb_x_preferred":[
         "Mzimba District"
     ],
@@ -72,6 +75,9 @@
     "name:guj_x_preferred":[
         "\u0aae\u0a9d\u0ac0\u0aac\u0abe \u0a9c\u0abf\u0ab2\u0acd\u0ab2\u0acb"
     ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d6\u05de\u05d1\u05d4"
+    ],
     "name:hin_x_preferred":[
         "\u091c\u093c\u093f\u092e\u094d\u092c\u093e \u091c\u093f\u0932\u093e"
     ],
@@ -90,6 +96,9 @@
     "name:kor_x_preferred":[
         "\uc74c\uc9d0\ubc14 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uc74c\uc9d0\ubc14\ud604"
+    ],
     "name:lav_x_preferred":[
         "Mzimbas distrikts"
     ],
@@ -101,6 +110,9 @@
     ],
     "name:msa_x_preferred":[
         "Mzimba District"
+    ],
+    "name:nan_x_preferred":[
+        "Mzimba Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Mzimba"
@@ -129,6 +141,9 @@
     "name:swe_x_preferred":[
         "Mzimba"
     ],
+    "name:tam_x_preferred":[
+        "\u0bae\u0b9c\u0bbf\u0bae\u0bcd\u0baa\u0bbe \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c0e\u0c02\u0c1c\u0c3f\u0c02\u0c2c\u0c3e \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
     ],
@@ -152,6 +167,9 @@
     ],
     "name:zho_x_preferred":[
         "\u59c6\u6d25\u5df4\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Mzimba District"
     ],
     "qs:name":"Mzimba District",
     "qs:photos_9r":0,
@@ -181,7 +199,7 @@
         }
     ],
     "wof:id":890438051,
-    "wof:lastmodified":1636497496,
+    "wof:lastmodified":1690846547,
     "wof:name":"Mzimba",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/053/890438053.geojson
+++ b/data/890/438/053/890438053.geojson
@@ -39,6 +39,9 @@
     "name:bul_x_preferred":[
         "\u041c\u0432\u0430\u043d\u0437\u0430"
     ],
+    "name:cat_x_preferred":[
+        "Mwanza"
+    ],
     "name:ceb_x_preferred":[
         "Mwanza District"
     ],
@@ -87,6 +90,9 @@
     "name:kor_x_preferred":[
         "\uc74c\uc644\uc790 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uc74c\uc644\uc790\ud604"
+    ],
     "name:lav_x_preferred":[
         "Mvanzas distrikts"
     ],
@@ -98,6 +104,9 @@
     ],
     "name:msa_x_preferred":[
         "Mwanza District"
+    ],
+    "name:nan_x_preferred":[
+        "Mwanza Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Mwanza"
@@ -122,6 +131,9 @@
     ],
     "name:swe_x_preferred":[
         "Mwanza"
+    ],
+    "name:tam_x_preferred":[
+        "\u0bae\u0bb5\u0ba9\u0bcd\u0b9a\u0b99\u0bcd \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c2e\u0c35\u0c3e\u0c02\u0c1c\u0c3e \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
@@ -153,6 +165,9 @@
     "name:zho_x_preferred":[
         "\u59c6\u842c\u7d2e\u7e23"
     ],
+    "name:zul_x_preferred":[
+        "Mwanza District"
+    ],
     "qs:name":"Mwanza District",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -181,7 +196,7 @@
         }
     ],
     "wof:id":890438053,
-    "wof:lastmodified":1636497495,
+    "wof:lastmodified":1690846545,
     "wof:name":"Mwanza",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/055/890438055.geojson
+++ b/data/890/438/055/890438055.geojson
@@ -39,6 +39,9 @@
     "name:bul_x_preferred":[
         "\u041c\u0443\u043b\u0430\u043d\u0438\u0435"
     ],
+    "name:cat_x_preferred":[
+        "Mulanje"
+    ],
     "name:ceb_x_preferred":[
         "Mulanje District"
     ],
@@ -87,6 +90,9 @@
     "name:kor_x_preferred":[
         "\ubb3c\ub780\uc81c \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ubb3c\ub780\uc81c\ud604"
+    ],
     "name:lav_x_preferred":[
         "Muland\u017ees distrikts"
     ],
@@ -98,6 +104,9 @@
     ],
     "name:msa_x_preferred":[
         "Mulanje District"
+    ],
+    "name:nan_x_preferred":[
+        "Mulanje Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Mulanje"
@@ -122,6 +131,9 @@
     ],
     "name:swe_x_preferred":[
         "Mulanje"
+    ],
+    "name:tam_x_preferred":[
+        "\u0bae\u0bc2\u0bb2\u0b9e\u0bcd\u0b9a\u0bc7 \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c2e\u0c41\u0c32\u0c3e\u0c02\u0c1c\u0c46 \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
@@ -149,6 +161,9 @@
     ],
     "name:zho_x_preferred":[
         "\u59c6\u862d\u5091\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Mulanje District"
     ],
     "qs:name":"Mulanje District",
     "qs:photos_9r":0,
@@ -178,7 +193,7 @@
         }
     ],
     "wof:id":890438055,
-    "wof:lastmodified":1636497495,
+    "wof:lastmodified":1690846545,
     "wof:name":"Mulanje",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/057/890438057.geojson
+++ b/data/890/438/057/890438057.geojson
@@ -84,6 +84,9 @@
     "name:kor_x_preferred":[
         "\uc74c\uce5c\uc9c0 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uc74c\uce5c\uc9c0\ud604"
+    ],
     "name:lav_x_preferred":[
         "M\u010dind\u017ei distrikts"
     ],
@@ -95,6 +98,9 @@
     ],
     "name:msa_x_preferred":[
         "Daerah Mchinji"
+    ],
+    "name:nan_x_preferred":[
+        "Mchinji Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Mchinji"
@@ -119,6 +125,9 @@
     ],
     "name:swe_x_preferred":[
         "Mchinji"
+    ],
+    "name:tam_x_preferred":[
+        "\u0bae\u0b9a\u0bbf\u0b9e\u0bcd\u0b9a\u0bbf \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c2e\u0c3e\u0c1a\u0c3f\u0c02\u0c1c\u0c3f \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
@@ -146,6 +155,9 @@
     ],
     "name:zho_x_preferred":[
         "\u59c6\u6b3d\u5409\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Mchinji District"
     ],
     "qs:name":"Mchinji District",
     "qs:photos_9r":0,
@@ -175,7 +187,7 @@
         }
     ],
     "wof:id":890438057,
-    "wof:lastmodified":1636497496,
+    "wof:lastmodified":1690846546,
     "wof:name":"Mchinji",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/059/890438059.geojson
+++ b/data/890/438/059/890438059.geojson
@@ -87,6 +87,9 @@
     "name:kor_x_preferred":[
         "\ub9dd\uace0\uce58 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ub9dd\uace0\uce58\ud604"
+    ],
     "name:lav_x_preferred":[
         "Mangon\u010di distrikts"
     ],
@@ -98,6 +101,9 @@
     ],
     "name:msa_x_preferred":[
         "Daerah Mangochi"
+    ],
+    "name:nan_x_preferred":[
+        "Mangochi Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Mangochi"
@@ -153,6 +159,9 @@
     "name:zho_x_preferred":[
         "\u66fc\u6208\u5207\u7e23"
     ],
+    "name:zul_x_preferred":[
+        "Mangochi District"
+    ],
     "qs:name":"Mangochi District",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -181,7 +190,7 @@
         }
     ],
     "wof:id":890438059,
-    "wof:lastmodified":1636497495,
+    "wof:lastmodified":1690846546,
     "wof:name":"Mangochi",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/061/890438061.geojson
+++ b/data/890/438/061/890438061.geojson
@@ -90,6 +90,9 @@
     "name:kor_x_preferred":[
         "\ub9c8\uce6d\uac00 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ub9c8\uce6d\uac00\ud604"
+    ],
     "name:lav_x_preferred":[
         "Ma\u010dingas distrikts"
     ],
@@ -101,6 +104,9 @@
     ],
     "name:msa_x_preferred":[
         "Daerah Machinga"
+    ],
+    "name:nan_x_preferred":[
+        "Machinga Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Machinga"
@@ -125,6 +131,9 @@
     ],
     "name:swe_x_preferred":[
         "Machinga"
+    ],
+    "name:tam_x_preferred":[
+        "\u0bae\u0b9a\u0bbf\u0b99\u0bcd\u0b95\u0bbe \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c2e\u0c1a\u0c3f\u0c02\u0c17\u0c3e \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
@@ -159,6 +168,9 @@
     "name:zho_x_preferred":[
         "\u99ac\u6b3d\u52a0\u7e23"
     ],
+    "name:zul_x_preferred":[
+        "Machinga District"
+    ],
     "qs:name":"Machinga District",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -187,7 +199,7 @@
         }
     ],
     "wof:id":890438061,
-    "wof:lastmodified":1636497495,
+    "wof:lastmodified":1690846546,
     "wof:name":"Machinga",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/063/890438063.geojson
+++ b/data/890/438/063/890438063.geojson
@@ -96,6 +96,9 @@
     "name:kor_x_preferred":[
         "\uce74\uc22d\uad6c \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uce74\uc22d\uad6c\ud604"
+    ],
     "name:lav_x_preferred":[
         "Kasungu distrikts"
     ],
@@ -110,6 +113,9 @@
     ],
     "name:msa_x_preferred":[
         "Daerah Kasungu"
+    ],
+    "name:nan_x_preferred":[
+        "Kasungu Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Kasungu"
@@ -135,6 +141,9 @@
     "name:swe_x_preferred":[
         "Kasungu"
     ],
+    "name:tam_x_preferred":[
+        "\u0b95\u0bbe\u0b9a\u0bc1\u0b95\u0bcd\u0b95\u0bc1 \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c15\u0c38\u0c41\u0c02\u0c17\u0c41 \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
     ],
@@ -155,6 +164,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u677e\u53e4\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Kasungu District"
     ],
     "qs:name":"Kasungu District",
     "qs:photos_9r":0,
@@ -184,7 +196,7 @@
         }
     ],
     "wof:id":890438063,
-    "wof:lastmodified":1636497495,
+    "wof:lastmodified":1690846545,
     "wof:name":"Kasungu",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/065/890438065.geojson
+++ b/data/890/438/065/890438065.geojson
@@ -33,8 +33,14 @@
     "name:bul_x_preferred":[
         "\u041a\u0430\u0440\u043e\u043d\u0433\u0430"
     ],
+    "name:cat_x_preferred":[
+        "Karonga"
+    ],
     "name:ceb_x_preferred":[
         "Karonga District"
+    ],
+    "name:deu_x_preferred":[
+        "Karonga Distrikt"
     ],
     "name:eng_x_preferred":[
         "Karonga"
@@ -51,6 +57,9 @@
     "name:fra_x_preferred":[
         "Karonga"
     ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05e7\u05e8\u05d5\u05e0\u05d2\u05d4"
+    ],
     "name:ind_x_preferred":[
         "Karonga"
     ],
@@ -65,6 +74,12 @@
     ],
     "name:kor_x_preferred":[
         "\uce74\ub871\uac00 \ud604"
+    ],
+    "name:kor_x_variant":[
+        "\uce74\ub871\uac00\ud604"
+    ],
+    "name:nan_x_preferred":[
+        "Karonga Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Karonga"
@@ -105,6 +120,9 @@
     "name:zho_x_preferred":[
         "\u5361\u9f8d\u52a0\u7e23"
     ],
+    "name:zul_x_preferred":[
+        "Karonga District"
+    ],
     "qs:name":"Karonga District",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -135,7 +153,7 @@
         }
     ],
     "wof:id":890438065,
-    "wof:lastmodified":1636497495,
+    "wof:lastmodified":1690846544,
     "wof:name":"Karonga",
     "wof:parent_id":1108784757,
     "wof:placetype":"county",

--- a/data/890/438/069/890438069.geojson
+++ b/data/890/438/069/890438069.geojson
@@ -39,6 +39,9 @@
     "name:bul_x_preferred":[
         "\u0414\u043e\u0432\u0430"
     ],
+    "name:cat_x_preferred":[
+        "Dowa"
+    ],
     "name:ceb_x_preferred":[
         "Dowa District"
     ],
@@ -93,6 +96,9 @@
     "name:kor_x_preferred":[
         "\ub3c4\uc640 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ub3c4\uc640\ud604"
+    ],
     "name:lav_x_preferred":[
         "Dovas re\u0123ions"
     ],
@@ -104,6 +110,9 @@
     ],
     "name:msa_x_preferred":[
         "Daerah Dowa"
+    ],
+    "name:nan_x_preferred":[
+        "Dowa Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Dowa"
@@ -129,6 +138,9 @@
     "name:swe_x_preferred":[
         "Dowa"
     ],
+    "name:tam_x_preferred":[
+        "\u0b9f\u0bcb\u0bb5\u0bbe \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c21\u0c4b\u0c35\u0c3e \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
     ],
@@ -149,6 +161,9 @@
     ],
     "name:zho_x_preferred":[
         "\u591a\u74e6\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Dowa District"
     ],
     "qs:name":"Dowa District",
     "qs:photos_9r":0,
@@ -178,7 +193,7 @@
         }
     ],
     "wof:id":890438069,
-    "wof:lastmodified":1636497496,
+    "wof:lastmodified":1690846546,
     "wof:name":"Dowa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/441/735/890441735.geojson
+++ b/data/890/441/735/890441735.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:ast_x_preferred":[
+        "Liwonde"
+    ],
     "name:azb_x_preferred":[
         "\u0644\u06cc\u0648\u0648\u0646\u062f\u0647"
     ],
@@ -33,6 +36,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0644\u06cc\u0648\u0648\u0646\u062f\u0647"
+    ],
+    "name:fin_x_preferred":[
+        "Liwonde"
     ],
     "name:fra_x_preferred":[
         "Liwonde"
@@ -61,6 +67,9 @@
     "name:por_x_preferred":[
         "Liwonde"
     ],
+    "name:swa_x_preferred":[
+        "Liwonde"
+    ],
     "name:swe_x_preferred":[
         "Liwonde"
     ],
@@ -75,6 +84,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5229\u7fc1\u4ee3"
+    ],
+    "name:zul_x_preferred":[
+        "Liwonde"
     ],
     "qs:name":"Liwonde",
     "qs:photos_9r":0,
@@ -107,7 +119,7 @@
         }
     ],
     "wof:id":890441735,
-    "wof:lastmodified":1566612567,
+    "wof:lastmodified":1690846542,
     "wof:name":"Liwonde",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/442/937/890442937.geojson
+++ b/data/890/442/937/890442937.geojson
@@ -90,6 +90,9 @@
     "name:kor_x_preferred":[
         "\ub370\uc790 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ub370\uc790\ud604"
+    ],
     "name:lav_x_preferred":[
         "Dedzas distrikts"
     ],
@@ -101,6 +104,9 @@
     ],
     "name:msa_x_preferred":[
         "Dedza District"
+    ],
+    "name:nan_x_preferred":[
+        "Dedza Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Dedza"
@@ -153,6 +159,9 @@
     "name:zho_x_preferred":[
         "\u4ee3\u624e\u7e23"
     ],
+    "name:zul_x_preferred":[
+        "Dedza District"
+    ],
     "qs:name":"Dedza District",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -181,7 +190,7 @@
         }
     ],
     "wof:id":890442937,
-    "wof:lastmodified":1636497496,
+    "wof:lastmodified":1690846547,
     "wof:name":"Dedza",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/825/890455825.geojson
+++ b/data/890/455/825/890455825.geojson
@@ -87,6 +87,9 @@
     "name:kor_x_preferred":[
         "\uc0b4\ub9ac\ub9c8 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uc0b4\ub9ac\ub9c8\ud604"
+    ],
     "name:lav_x_preferred":[
         "Salimas distrikts"
     ],
@@ -98,6 +101,9 @@
     ],
     "name:msa_x_preferred":[
         "Daerah Salima"
+    ],
+    "name:nan_x_preferred":[
+        "Salima Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Salima"
@@ -123,6 +129,9 @@
     "name:swe_x_preferred":[
         "Salima"
     ],
+    "name:tam_x_preferred":[
+        "\u0b9a\u0bb2\u0bc0\u0bae\u0bbe \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c38\u0c3e\u0c32\u0c3f\u0c2e\u0c3e \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
     ],
@@ -146,6 +155,9 @@
     ],
     "name:zho_x_preferred":[
         "\u85a9\u5229\u99ac\u7e23"
+    ],
+    "name:zul_x_preferred":[
+        "Salima District"
     ],
     "qs:name":"Salima District",
     "qs:photos_9r":0,
@@ -175,7 +187,7 @@
         }
     ],
     "wof:id":890455825,
-    "wof:lastmodified":1636497494,
+    "wof:lastmodified":1690846544,
     "wof:name":"Salima",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/827/890455827.geojson
+++ b/data/890/455/827/890455827.geojson
@@ -93,6 +93,9 @@
     "name:kor_x_preferred":[
         "\ub8f8\ud53c \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ub8f8\ud53c\ud604"
+    ],
     "name:lav_x_preferred":[
         "Rumfi distrikts"
     ],
@@ -104,6 +107,9 @@
     ],
     "name:msa_x_preferred":[
         "Rumphi District"
+    ],
+    "name:nan_x_preferred":[
+        "Rumphi Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Rumphi"
@@ -159,6 +165,9 @@
     "name:zho_x_preferred":[
         "\u502b\u6bd4\u7e23"
     ],
+    "name:zul_x_preferred":[
+        "Rumphi District"
+    ],
     "qs:name":"Rumphi District",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -187,7 +196,7 @@
         }
     ],
     "wof:id":890455827,
-    "wof:lastmodified":1636497494,
+    "wof:lastmodified":1690846543,
     "wof:name":"Rumphi",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/829/890455829.geojson
+++ b/data/890/455/829/890455829.geojson
@@ -30,6 +30,9 @@
     "name:aze_x_preferred":[
         "Thyolo"
     ],
+    "name:bel_x_preferred":[
+        "\u0422\u044b\u0451\u043b\u0430"
+    ],
     "name:ben_x_preferred":[
         "\u09a5\u09bf\u0993\u09b2\u09cb"
     ],
@@ -84,6 +87,12 @@
     "name:kor_x_preferred":[
         "\ud2f0\uc62c\ub85c \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ud2f0\uc62c\ub85c\ud604"
+    ],
+    "name:nan_x_preferred":[
+        "Thyolo Ko\u0101n"
+    ],
     "name:nld_x_preferred":[
         "Thyolo"
     ],
@@ -123,6 +132,9 @@
     "name:zho_x_preferred":[
         "\u8482\u7d04\u7f85\u7e23"
     ],
+    "name:zul_x_preferred":[
+        "Thyolo District"
+    ],
     "qs:name":"Thyolo District",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -151,7 +163,7 @@
         }
     ],
     "wof:id":890455829,
-    "wof:lastmodified":1636497494,
+    "wof:lastmodified":1690846543,
     "wof:name":"Thyolo",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/831/890455831.geojson
+++ b/data/890/455/831/890455831.geojson
@@ -39,6 +39,9 @@
     "name:bul_x_preferred":[
         "\u0427\u0438\u0440\u0430\u0434\u0437\u0443\u043b\u0443"
     ],
+    "name:cat_x_preferred":[
+        "Chiradzulu"
+    ],
     "name:ceb_x_preferred":[
         "Chiradzulu District"
     ],
@@ -87,6 +90,9 @@
     "name:kor_x_preferred":[
         "\uce58\ub77c\uc904\ub8e8 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uce58\ub77c\uc904\ub8e8\ud604"
+    ],
     "name:lav_x_preferred":[
         "\u010ciradzulu distrikts"
     ],
@@ -98,6 +104,9 @@
     ],
     "name:msa_x_preferred":[
         "Chiradzulu District"
+    ],
+    "name:nan_x_preferred":[
+        "Chiradzulu Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Chiradzulu"
@@ -150,6 +159,9 @@
     "name:zho_x_preferred":[
         "\u5947\u62c9\u6731\u76e7\u7e23"
     ],
+    "name:zul_x_preferred":[
+        "Chiradzulu District"
+    ],
     "qs:name":"Chiradzulu District",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -178,7 +190,7 @@
         }
     ],
     "wof:id":890455831,
-    "wof:lastmodified":1636497494,
+    "wof:lastmodified":1690846544,
     "wof:name":"Chiradzulu",
     "wof:parent_id":-1,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.