### PR TITLE
mw concordances, placetype local, and more

### DIFF
--- a/data/110/878/475/5/1108784755.geojson
+++ b/data/110/878/475/5/1108784755.geojson
@@ -67,8 +67,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"MW.LI"
+        "hasc:id":"MW.LI",
+        "iso:code":"MW-LI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MW",
     "wof:created":1481825955,
     "wof:geomhash":"b7d23a0df1d24e552ccbd65811b2f239",
@@ -88,7 +90,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884758,
     "wof:name":"Lilongwe City",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/110/878/475/7/1108784757.geojson
+++ b/data/110/878/475/7/1108784757.geojson
@@ -143,8 +143,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"MW.KR"
+        "hasc:id":"MW.KR",
+        "iso:code":"MW-KR"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MW",
     "wof:created":1481825960,
     "wof:geomhash":"9e8972fd095105eb0df67847d2f1690e",
@@ -164,7 +166,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1694493257,
+    "wof:lastmodified":1695884852,
     "wof:name":"Karonga",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/110/878/475/9/1108784759.geojson
+++ b/data/110/878/475/9/1108784759.geojson
@@ -67,8 +67,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"MW.MZ"
+        "hasc:id":"MW.MZ",
+        "iso:code":"MW-MZ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MW",
     "wof:created":1481825962,
     "wof:geomhash":"0d08df7a4780c01d71cb3896e15c6fa1",
@@ -88,7 +90,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884758,
     "wof:name":"Mzuzu City",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/110/878/476/1/1108784761.geojson
+++ b/data/110/878/476/1/1108784761.geojson
@@ -125,8 +125,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"MW.BL"
+        "hasc:id":"MW.BL",
+        "iso:code":"MW-BL"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MW",
     "wof:created":1481825965,
     "wof:geomhash":"aba559f805f0a6a526a55ef2e97a282d",
@@ -146,7 +148,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884758,
     "wof:name":"Blantyre City",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/110/878/476/5/1108784765.geojson
+++ b/data/110/878/476/5/1108784765.geojson
@@ -67,8 +67,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"MW.ZO"
+        "hasc:id":"MW.ZO",
+        "iso:code":"MW-ZO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MW",
     "wof:created":1481825971,
     "wof:geomhash":"cc4ccecf471181582f156675cb2cd530",
@@ -88,7 +90,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884758,
     "wof:name":"Zomba City",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/856/323/83/85632383.geojson
+++ b/data/856/323/83/85632383.geojson
@@ -1078,6 +1078,7 @@
         "hasc:id":"MW",
         "icao:code":"7Q",
         "ioc:id":"MAW",
+        "iso:code":"MW",
         "itu:id":"MWI",
         "loc:id":"n80089996",
         "m49:code":"454",
@@ -1092,6 +1093,7 @@
         "wk:page":"Malawi",
         "wmo:id":"MW"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MW",
     "wof:country_alpha3":"MWI",
     "wof:geom_alt":[
@@ -1114,7 +1116,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1694639521,
+    "wof:lastmodified":1695881177,
     "wof:name":"Malawi",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/751/15/85675115.geojson
+++ b/data/856/751/15/85675115.geojson
@@ -83,9 +83,11 @@
     ],
     "wof:concordances":{
         "gp:id":20070147,
+        "iso:code":"MW-LK",
         "qs_pg:id":236296,
         "unlc:id":"MW-LK"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MW",
     "wof:geomhash":"039a678afbbbc1262fe2dfd9ae54aeb2",
     "wof:hierarchy":[
@@ -104,7 +106,7 @@
         "nya",
         "eng"
     ],
-    "wof:lastmodified":1694493257,
+    "wof:lastmodified":1695884852,
     "wof:name":"Likoma",
     "wof:parent_id":85632383,
     "wof:placetype":"region",

--- a/data/890/422/339/890422339.geojson
+++ b/data/890/422/339/890422339.geojson
@@ -187,7 +187,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469051438,
-    "wof:geomhash":"a266513b9f6ed25fa8fd59c98cc61675",
+    "wof:geomhash":"2b29f3887e0aa317bdaae8f49e5bb857",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -196,7 +196,7 @@
         }
     ],
     "wof:id":890422339,
-    "wof:lastmodified":1690846542,
+    "wof:lastmodified":1695887147,
     "wof:name":"Chikwawa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/428/701/890428701.geojson
+++ b/data/890/428/701/890428701.geojson
@@ -187,7 +187,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469051765,
-    "wof:geomhash":"4f220a1cc820406fef411331293d6bb9",
+    "wof:geomhash":"bb3e485ab7a55d7c0955a7dbcc6b3140",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -196,7 +196,7 @@
         }
     ],
     "wof:id":890428701,
-    "wof:lastmodified":1690846547,
+    "wof:lastmodified":1695887148,
     "wof:name":"Phalombe",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/430/565/890430565.geojson
+++ b/data/890/430/565/890430565.geojson
@@ -184,7 +184,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469051857,
-    "wof:geomhash":"92ad310dbab0b7ea6db1f5c2505adcd4",
+    "wof:geomhash":"aff448a3c3b015981b114ca10bbe0c87",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -193,7 +193,7 @@
         }
     ],
     "wof:id":890430565,
-    "wof:lastmodified":1690846543,
+    "wof:lastmodified":1695887147,
     "wof:name":"Ntchisi",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/430/567/890430567.geojson
+++ b/data/890/430/567/890430567.geojson
@@ -181,7 +181,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469051858,
-    "wof:geomhash":"3d818a76c9824a73e3c2d35161c18166",
+    "wof:geomhash":"3c93468bd74abfe9e6c9a5b60d9b311c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -190,7 +190,7 @@
         }
     ],
     "wof:id":890430567,
-    "wof:lastmodified":1690846542,
+    "wof:lastmodified":1695887147,
     "wof:name":"Nsanje",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/430/569/890430569.geojson
+++ b/data/890/430/569/890430569.geojson
@@ -187,7 +187,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469051858,
-    "wof:geomhash":"0fa7e2fcb82bb1574728622f12bb9cfa",
+    "wof:geomhash":"6b0813448b36a37f00eb032b3cc82d78",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -196,7 +196,7 @@
         }
     ],
     "wof:id":890430569,
-    "wof:lastmodified":1690846542,
+    "wof:lastmodified":1695887147,
     "wof:name":"Nkhotakota",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/435/513/890435513.geojson
+++ b/data/890/435/513/890435513.geojson
@@ -187,7 +187,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052070,
-    "wof:geomhash":"9ca735536ef1773e85683722a50c7ffd",
+    "wof:geomhash":"04aa6e77e2d089cbe2e8bfa2b587c283",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -196,7 +196,7 @@
         }
     ],
     "wof:id":890435513,
-    "wof:lastmodified":1690846547,
+    "wof:lastmodified":1695887148,
     "wof:name":"Balaka",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/045/890438045.geojson
+++ b/data/890/438/045/890438045.geojson
@@ -187,7 +187,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052178,
-    "wof:geomhash":"c4b88a89655fde812cf8dcce2ed91f88",
+    "wof:geomhash":"10ecf7114bd4b0d98fee890081e68812",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -196,7 +196,7 @@
         }
     ],
     "wof:id":890438045,
-    "wof:lastmodified":1690846545,
+    "wof:lastmodified":1695887148,
     "wof:name":"Nkhata Bay",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/047/890438047.geojson
+++ b/data/890/438/047/890438047.geojson
@@ -181,7 +181,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052178,
-    "wof:geomhash":"e8a125fd505cef72a82f5c6c09adef3d",
+    "wof:geomhash":"c96853538b2a7b6b315af8325c6cd4fd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -190,7 +190,7 @@
         }
     ],
     "wof:id":890438047,
-    "wof:lastmodified":1690846544,
+    "wof:lastmodified":1695887147,
     "wof:name":"Ntcheu",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/051/890438051.geojson
+++ b/data/890/438/051/890438051.geojson
@@ -190,7 +190,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052178,
-    "wof:geomhash":"418c6ff5e381717661da5498517f615b",
+    "wof:geomhash":"25c8c97903bc1efef4014a5a5e6a572c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -199,7 +199,7 @@
         }
     ],
     "wof:id":890438051,
-    "wof:lastmodified":1690846547,
+    "wof:lastmodified":1695887148,
     "wof:name":"Mzimba",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/053/890438053.geojson
+++ b/data/890/438/053/890438053.geojson
@@ -187,7 +187,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052178,
-    "wof:geomhash":"46703136b5c25d89036ef8dac5013294",
+    "wof:geomhash":"1803ea7edb6174b502434af926f38fee",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -196,7 +196,7 @@
         }
     ],
     "wof:id":890438053,
-    "wof:lastmodified":1690846545,
+    "wof:lastmodified":1695887148,
     "wof:name":"Mwanza",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/055/890438055.geojson
+++ b/data/890/438/055/890438055.geojson
@@ -184,7 +184,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052178,
-    "wof:geomhash":"8c851e4deb50e1836cc1af373db8dfa9",
+    "wof:geomhash":"1e16fcb6a8650000a8d44daeaf9cfd91",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -193,7 +193,7 @@
         }
     ],
     "wof:id":890438055,
-    "wof:lastmodified":1690846545,
+    "wof:lastmodified":1695887148,
     "wof:name":"Mulanje",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/057/890438057.geojson
+++ b/data/890/438/057/890438057.geojson
@@ -178,7 +178,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052178,
-    "wof:geomhash":"4355e24ab6cba1822b7b8a78ab57cd36",
+    "wof:geomhash":"94707d424814ef4f14e17cddb4ae32cd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -187,7 +187,7 @@
         }
     ],
     "wof:id":890438057,
-    "wof:lastmodified":1690846546,
+    "wof:lastmodified":1695887148,
     "wof:name":"Mchinji",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/059/890438059.geojson
+++ b/data/890/438/059/890438059.geojson
@@ -181,7 +181,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052178,
-    "wof:geomhash":"a468c7c4ec826881d68a95568f56e505",
+    "wof:geomhash":"cd8a4b557ccd39ac41ce21855bbfad41",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -190,7 +190,7 @@
         }
     ],
     "wof:id":890438059,
-    "wof:lastmodified":1690846546,
+    "wof:lastmodified":1695887148,
     "wof:name":"Mangochi",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/061/890438061.geojson
+++ b/data/890/438/061/890438061.geojson
@@ -190,7 +190,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052178,
-    "wof:geomhash":"925eba4ca2cfba2732f75b5d95523a90",
+    "wof:geomhash":"3514b338f7ce06b896ba7f88a868d8b4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -199,7 +199,7 @@
         }
     ],
     "wof:id":890438061,
-    "wof:lastmodified":1690846546,
+    "wof:lastmodified":1695887148,
     "wof:name":"Machinga",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/063/890438063.geojson
+++ b/data/890/438/063/890438063.geojson
@@ -187,7 +187,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052178,
-    "wof:geomhash":"eb080d371bc1cdcc7c27cb35cd64abac",
+    "wof:geomhash":"70d577c9f6ae1a39bdc7dfbe367660d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -196,7 +196,7 @@
         }
     ],
     "wof:id":890438063,
-    "wof:lastmodified":1690846545,
+    "wof:lastmodified":1695887148,
     "wof:name":"Kasungu",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/438/065/890438065.geojson
+++ b/data/890/438/065/890438065.geojson
@@ -143,7 +143,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052178,
-    "wof:geomhash":"dccafabcd5b730c7eae8b3defd3c6e51",
+    "wof:geomhash":"a3f28363b749aa1c4533baddf0f10d28",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -153,7 +153,7 @@
         }
     ],
     "wof:id":890438065,
-    "wof:lastmodified":1690846544,
+    "wof:lastmodified":1695887148,
     "wof:name":"Karonga",
     "wof:parent_id":1108784757,
     "wof:placetype":"county",

--- a/data/890/438/069/890438069.geojson
+++ b/data/890/438/069/890438069.geojson
@@ -184,7 +184,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052178,
-    "wof:geomhash":"38ad25544a03098eab63012e9de6e279",
+    "wof:geomhash":"1d72ceae9db5d18ce61ba45ee88edb75",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -193,7 +193,7 @@
         }
     ],
     "wof:id":890438069,
-    "wof:lastmodified":1690846546,
+    "wof:lastmodified":1695887148,
     "wof:name":"Dowa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/442/937/890442937.geojson
+++ b/data/890/442/937/890442937.geojson
@@ -181,7 +181,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052389,
-    "wof:geomhash":"7a5f177dd018beb88db6e98283ddd649",
+    "wof:geomhash":"9f5814983144e5688be76a65c90ff3a2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -190,7 +190,7 @@
         }
     ],
     "wof:id":890442937,
-    "wof:lastmodified":1690846547,
+    "wof:lastmodified":1695887148,
     "wof:name":"Dedza",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/825/890455825.geojson
+++ b/data/890/455/825/890455825.geojson
@@ -178,7 +178,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052977,
-    "wof:geomhash":"2445f2a059339886eaf88dcf7fb79a5e",
+    "wof:geomhash":"cb5358e21bd9cde318e1ca7fc2f038e8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -187,7 +187,7 @@
         }
     ],
     "wof:id":890455825,
-    "wof:lastmodified":1690846544,
+    "wof:lastmodified":1695887147,
     "wof:name":"Salima",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/827/890455827.geojson
+++ b/data/890/455/827/890455827.geojson
@@ -187,7 +187,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052977,
-    "wof:geomhash":"4afb6a9077f63abcb7ad8488c3b57658",
+    "wof:geomhash":"f605b0c2579f4c6b23f33f5f644f1692",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -196,7 +196,7 @@
         }
     ],
     "wof:id":890455827,
-    "wof:lastmodified":1690846543,
+    "wof:lastmodified":1695887147,
     "wof:name":"Rumphi",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/829/890455829.geojson
+++ b/data/890/455/829/890455829.geojson
@@ -154,7 +154,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052977,
-    "wof:geomhash":"2894fa8d5cb7f6361a40ccda3e8b3e80",
+    "wof:geomhash":"842b3a7af7cef7b540a1c97b9cd6458d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -163,7 +163,7 @@
         }
     ],
     "wof:id":890455829,
-    "wof:lastmodified":1690846543,
+    "wof:lastmodified":1695887148,
     "wof:name":"Thyolo",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/455/831/890455831.geojson
+++ b/data/890/455/831/890455831.geojson
@@ -181,7 +181,7 @@
     },
     "wof:country":"MW",
     "wof:created":1469052977,
-    "wof:geomhash":"6a7343a8802c9b390c25bd947845acc8",
+    "wof:geomhash":"12a180ccbf9b82a8f39e93df583e0e87",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -190,7 +190,7 @@
         }
     ],
     "wof:id":890455831,
-    "wof:lastmodified":1690846544,
+    "wof:lastmodified":1695887148,
     "wof:name":"Chiradzulu",
     "wof:parent_id":-1,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.